### PR TITLE
Upgrade to srcML 1.0 - Groundwork update

### DIFF
--- a/ABB.SrcML.Test/SrcMLCppAPITests.cs
+++ b/ABB.SrcML.Test/SrcMLCppAPITests.cs
@@ -7,11 +7,7 @@ using NUnit.Framework;
 using ABB.SrcML;
 using System.Xml;
 using System.Runtime.InteropServices;
-/*
- *             Int32 ret = Reset(ptr);
-            control = (Register)Marshal.PtrToStructure(ptr, typeof(control));
-            Marshal.FreeHGlobal(ptr);
-            ptr = IntPtr.Zero;*/
+
 namespace ABB.SrcML.Test {
 
     [TestFixture]
@@ -53,7 +49,6 @@ namespace ABB.SrcML.Test {
                       where ele.Attribute("filename").Value == file1
                       select ele);
             Assert.AreEqual("input2.cpp", f2.FirstOrDefault().Attribute("filename").Value);
-            //Further testing should check for units
         }
         /// TODO: This requires some modifications to be made to SrcMLFile so that it can take strings of xml. Going to do
         /// A pull of what I have so far before I go making those kinds of changes.

--- a/ABB.SrcML/SrcMLCppAPI.cs
+++ b/ABB.SrcML/SrcMLCppAPI.cs
@@ -7,60 +7,60 @@ namespace ABB.SrcML {
     public class SrcMLCppAPI {
         public struct SrcMLOptions {
             /** Create an archive */
-            public static const ulong SRCML_OPTION_ARCHIVE = 1 << 0;
+            public const ulong SRCML_OPTION_ARCHIVE = 1 << 0;
             /** Include line/column position attributes */
-            public static const ulong SRCML_OPTION_POSITION = 1 << 1;
+            public const ulong SRCML_OPTION_POSITION = 1 << 1;
             /** Markup preprocessor elements (default for C, C++, C#) */
-            public static const ulong SRCML_OPTION_CPP_NOMACRO = 1 << 2;
+            public const ulong SRCML_OPTION_CPP_NOMACRO = 1 << 2;
             /** Markup preprocessor elements (default for C, C++) */
-            public static const ulong SRCML_OPTION_CPP = 1 << 2 | 1 << 3;
+            public const ulong SRCML_OPTION_CPP = 1 << 2 | 1 << 3;
             /** Issue an XML declaration */
-            public static const ulong SRCML_OPTION_XML_DECL = 1 << 4;
+            public const ulong SRCML_OPTION_XML_DECL = 1 << 4;
             /** Include any XML namespace declarations */
-            public static const ulong SRCML_OPTION_NAMESPACE_DECL = 1 << 5;
+            public const ulong SRCML_OPTION_NAMESPACE_DECL = 1 << 5;
             /** Leave as text preprocessor else parts (default: markup) */
-            public static const ulong SRCML_OPTION_CPP_TEXT_ELSE = 1 << 6;
+            public const ulong SRCML_OPTION_CPP_TEXT_ELSE = 1 << 6;
             /** Markup preprocessor @code #if 0 @endcode sections (default: leave as text) */
-            public static const ulong SRCML_OPTION_CPP_MARKUP_IF0 = 1 << 7;
+            public const ulong SRCML_OPTION_CPP_MARKUP_IF0 = 1 << 7;
             /** Apply transformations to the entire srcML file (default: each unit */
-            public static const ulong SRCML_OPTION_APPLY_ROOT = 1 << 8;
+            public const ulong SRCML_OPTION_APPLY_ROOT = 1 << 8;
             /** Nest if in else if intead of elseif tag */
-            public static const ulong SRCML_OPTION_NESTIF = 1 << 9;
+            public const ulong SRCML_OPTION_NESTIF = 1 << 9;
             /** Output hash attribute on each unit (default: on) */
-            public static const ulong SRCML_OPTION_HASH = 1 << 10;
+            public const ulong SRCML_OPTION_HASH = 1 << 10;
             /** Wrap function/classes/etc with templates (default: on) */
-            public static const ulong SRCML_OPTION_WRAP_TEMPLATE = 1 << 11;
+            public const ulong SRCML_OPTION_WRAP_TEMPLATE = 1 << 11;
             /** output is interactive (good for editing applications) */
-            public static const ulong SRCML_OPTION_INTERACTIVE = 1 << 12;
+            public const ulong SRCML_OPTION_INTERACTIVE = 1 << 12;
             /** Not sure what this used for */
-            public static const ulong SRCML_OPTION_XPATH_TOTAL = 1 << 13;
+            public const ulong SRCML_OPTION_XPATH_TOTAL = 1 << 13;
             /** expression mode */
-            public static const ulong SRCML_OPTION_EXPRESSION = 1 << 14;
+            public const ulong SRCML_OPTION_EXPRESSION = 1 << 14;
             /** Extra processing of @code#line@endcode for position information */
-            public static const ulong SRCML_OPTION_LINE = 1 << 15;
+            public const ulong SRCML_OPTION_LINE = 1 << 15;
             /** additional cpp:if/cpp:endif checking */
-            public static const ulong SRCML_OPTION_CPPIF_CHECK = 1 << 16;
+            public const ulong SRCML_OPTION_CPPIF_CHECK = 1 << 16;
             /** debug time attribute */
-            public static const ulong SRCML_OPTION_DEBUG_TIMER = 1 << 17;
+            public const ulong SRCML_OPTION_DEBUG_TIMER = 1 << 17;
             /** turn on optional ternary operator markup */
-            public static const ulong SRCML_OPTION_TERNARY = 1 << 18;
+            public const ulong SRCML_OPTION_TERNARY = 1 << 18;
             /** turn on optional ternary operator markup */
-            public static const ulong SRCML_OPTION_PSEUDO_BLOCK = 1 << 19;
+            public const ulong SRCML_OPTION_PSEUDO_BLOCK = 1 << 19;
             /** Turn on old optional markup behaviour */
-            public static const ulong SRCML_OPTION_OPTIONAL_MARKUP = 1 << 20;
+            public const ulong SRCML_OPTION_OPTIONAL_MARKUP = 1 << 20;
             /** Markups literal in special namespace */
-            public static const ulong SRCML_OPTION_LITERAL = 1 << 21;
+            public const ulong SRCML_OPTION_LITERAL = 1 << 21;
             /** Markups modifiers in special namespace */
-            public static const ulong SRCML_OPTION_MODIFIER = 1 << 22;
+            public const ulong SRCML_OPTION_MODIFIER = 1 << 22;
             /** Markups operator in special namespace */
-            public static const ulong SRCML_OPTION_OPERATOR = 1 << 23;
+            public const ulong SRCML_OPTION_OPERATOR = 1 << 23;
             /** Parser output special tokens for debugging the parser */
-            public static const ulong SRCML_OPTION_DEBUG = 1 << 24;
+            public const ulong SRCML_OPTION_DEBUG = 1 << 24;
             /** Markups OpenMP in special namespace */
-            public static const ulong SRCML_OPTION_OPENMP = 1 << 25;
+            public const ulong SRCML_OPTION_OPENMP = 1 << 25;
             /** Encode the original source encoding as an attribute */
-            public static const ulong SRCML_OPTION_STORE_ENCODING = 1 << 26;
-            public static const ulong SRCML_OPTION_DEFAULT = (SRCML_OPTION_ARCHIVE | SRCML_OPTION_XML_DECL | SRCML_OPTION_NAMESPACE_DECL | SRCML_OPTION_HASH | SRCML_OPTION_PSEUDO_BLOCK | SRCML_OPTION_TERNARY);
+            public const ulong SRCML_OPTION_STORE_ENCODING = 1 << 26;
+            public const ulong SRCML_OPTION_DEFAULT = (SRCML_OPTION_ARCHIVE | SRCML_OPTION_XML_DECL | SRCML_OPTION_NAMESPACE_DECL | SRCML_OPTION_HASH | SRCML_OPTION_PSEUDO_BLOCK | SRCML_OPTION_TERNARY);
         }
         [StructLayout(LayoutKind.Sequential, Pack=1)]
         public struct ArchiveAdapter {

--- a/ABB.SrcML/SrcMLCppAPI.cs
+++ b/ABB.SrcML/SrcMLCppAPI.cs
@@ -5,10 +5,111 @@ using System.Text;
 using System.Runtime.InteropServices;
 namespace ABB.SrcML {
     public class SrcMLCppAPI {
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        public struct ArchiveAdapter {
+            //[MarshalAs(UnmanagedType.U1);
+            private IntPtr encoding;
+            private IntPtr src_encoding;
+            private IntPtr revision;
+            private IntPtr language;
+            private IntPtr filename;
+            private IntPtr url;
+            private IntPtr version;
+            private IntPtr timestamp;
+            private IntPtr hash;
+            private int tabstop;
+            /// <summary>
+            /// Sets the encoding for source code
+            /// </summary>
+            /// <param name="sourceEncoding">The encoding to be set</param>
+            public void SetArchiveSrcEncoding(string sourceEncoding) {
+                src_encoding = Marshal.StringToHGlobalAnsi(sourceEncoding);
+            }
+            /// <summary>
+            /// Sets the xml encoding for the archive
+            /// </summary>
+            /// <param name="xmlEncoding">The chosen encoding</param>
+            public void SetArchiveXmlEncoding(string xmlEncoding) {
+                encoding = Marshal.StringToHGlobalAnsi(xmlEncoding);
+            }
+            /// <summary>
+            /// Language that srcML should assume for the given document(s)
+            /// </summary>
+            /// <param name="lang">The chosen language</param>
+            public void SetArchiveLanguage(string lang) {
+                language = Marshal.StringToHGlobalAnsi(lang);
+            }
+            /// <summary>
+            /// Name for the archive being created. This gets set on the <unit>
+            /// </summary>
+            /// <param name="fname">Chosen name for file</param>
+            public void SetArchiveFilename(string fname) {
+                filename = Marshal.StringToHGlobalAnsi(fname);
+            }
+            /// <summary>
+            /// URL for namespace in archive
+            /// </summary>
+            /// <param name="srcurl">Chosen URL</param>
+            public void SetArchiveUrl(string srcurl) {
+                url = Marshal.StringToHGlobalAnsi(srcurl);
+            }
+            /// <summary>
+            /// Version of srcML that generated this archive
+            /// </summary>
+            /// <param name="srcVersion">Version number</param>
+            public void SetArchiveSrcVersion(string srcVersion) {
+                version = Marshal.StringToHGlobalAnsi(srcVersion);
+            }
+            /// <summary>
+            /// TODO
+            /// </summary>
+            /// <param name="srctab"></param>
+            public void SetArchiveTabstop(int srctab) {
+                tabstop = srctab;
+            }
+            /// <summary>
+            /// Timestamp for when archive was generated
+            /// </summary>
+            /// <param name="srcTimestamp">The time</param>
+            public void SetArchiveTimestamp(string srcTimestamp) {
+                timestamp = Marshal.StringToHGlobalAnsi(srcTimestamp);
+            }
+            /// <summary>
+            /// TODO
+            /// </summary>
+            /// <param name="srcHash"></param>
+            public void srcml_set_hash(string srcHash) {
+                hash = Marshal.StringToHGlobalAnsi(srcHash);
+            }
+            void srcml_set_options(long option) {
+                //To be implemented
+            }
+            //int srcml_disable_option            (long option);
+            //int srcml_set_tabstop               (int tabstop);
+            //int srcml_register_file_extension   (string  extension, string language);
+            //int srcml_register_namespace        (string  prefix, string ns);
+            //int srcml_set_processing_instruction(string  target, string data); 
+            //int srcml_register_macro            (string  token, string type);
+            //int srcml_unparse_set_eol           (int eol);
+        }
+        public static IntPtr CreatePtrFromStruct(SrcMLCppAPI.ArchiveAdapter ad) {
+            int size = Marshal.SizeOf(ad);
+            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(ad));
+            Marshal.StructureToPtr(ad, ptr, false);
+            return ptr;
+        }
         [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
-        public static extern int SrcmlCreateArchiveFromListOfFiles(string[] argv, int argc, string outputFile);
+        public static extern int SrcmlCreateArchiveFtF(string[] argv, int argc, string outputFile, IntPtr Adapter);
+        
+        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern int SrcmlCreateArchiveMtF(string argv, int argc, string outputFile, IntPtr Adapter);
+        
         [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
         [return: MarshalAs(UnmanagedType.LPStr)]
-        public static extern string SrcmlCreateArchiveInMemory(string[] argv, int argc);
+        public static extern string SrcmlCreateArchiveFtM(string[] argv, int argc, IntPtr Adapter);
+        
+        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.LPStr)]
+        public static extern string SrcmlCreateArchiveMtM(string argv, int argc, IntPtr Adapter);
     }
 }

--- a/ABB.SrcML/SrcMLCppAPI.cs
+++ b/ABB.SrcML/SrcMLCppAPI.cs
@@ -5,9 +5,65 @@ using System.Text;
 using System.Runtime.InteropServices;
 namespace ABB.SrcML {
     public class SrcMLCppAPI {
+        public struct SrcMLOptions {
+            /** Create an archive */
+            public static const ulong SRCML_OPTION_ARCHIVE = 1 << 0;
+            /** Include line/column position attributes */
+            public static const ulong SRCML_OPTION_POSITION = 1 << 1;
+            /** Markup preprocessor elements (default for C, C++, C#) */
+            public static const ulong SRCML_OPTION_CPP_NOMACRO = 1 << 2;
+            /** Markup preprocessor elements (default for C, C++) */
+            public static const ulong SRCML_OPTION_CPP = 1 << 2 | 1 << 3;
+            /** Issue an XML declaration */
+            public static const ulong SRCML_OPTION_XML_DECL = 1 << 4;
+            /** Include any XML namespace declarations */
+            public static const ulong SRCML_OPTION_NAMESPACE_DECL = 1 << 5;
+            /** Leave as text preprocessor else parts (default: markup) */
+            public static const ulong SRCML_OPTION_CPP_TEXT_ELSE = 1 << 6;
+            /** Markup preprocessor @code #if 0 @endcode sections (default: leave as text) */
+            public static const ulong SRCML_OPTION_CPP_MARKUP_IF0 = 1 << 7;
+            /** Apply transformations to the entire srcML file (default: each unit */
+            public static const ulong SRCML_OPTION_APPLY_ROOT = 1 << 8;
+            /** Nest if in else if intead of elseif tag */
+            public static const ulong SRCML_OPTION_NESTIF = 1 << 9;
+            /** Output hash attribute on each unit (default: on) */
+            public static const ulong SRCML_OPTION_HASH = 1 << 10;
+            /** Wrap function/classes/etc with templates (default: on) */
+            public static const ulong SRCML_OPTION_WRAP_TEMPLATE = 1 << 11;
+            /** output is interactive (good for editing applications) */
+            public static const ulong SRCML_OPTION_INTERACTIVE = 1 << 12;
+            /** Not sure what this used for */
+            public static const ulong SRCML_OPTION_XPATH_TOTAL = 1 << 13;
+            /** expression mode */
+            public static const ulong SRCML_OPTION_EXPRESSION = 1 << 14;
+            /** Extra processing of @code#line@endcode for position information */
+            public static const ulong SRCML_OPTION_LINE = 1 << 15;
+            /** additional cpp:if/cpp:endif checking */
+            public static const ulong SRCML_OPTION_CPPIF_CHECK = 1 << 16;
+            /** debug time attribute */
+            public static const ulong SRCML_OPTION_DEBUG_TIMER = 1 << 17;
+            /** turn on optional ternary operator markup */
+            public static const ulong SRCML_OPTION_TERNARY = 1 << 18;
+            /** turn on optional ternary operator markup */
+            public static const ulong SRCML_OPTION_PSEUDO_BLOCK = 1 << 19;
+            /** Turn on old optional markup behaviour */
+            public static const ulong SRCML_OPTION_OPTIONAL_MARKUP = 1 << 20;
+            /** Markups literal in special namespace */
+            public static const ulong SRCML_OPTION_LITERAL = 1 << 21;
+            /** Markups modifiers in special namespace */
+            public static const ulong SRCML_OPTION_MODIFIER = 1 << 22;
+            /** Markups operator in special namespace */
+            public static const ulong SRCML_OPTION_OPERATOR = 1 << 23;
+            /** Parser output special tokens for debugging the parser */
+            public static const ulong SRCML_OPTION_DEBUG = 1 << 24;
+            /** Markups OpenMP in special namespace */
+            public static const ulong SRCML_OPTION_OPENMP = 1 << 25;
+            /** Encode the original source encoding as an attribute */
+            public static const ulong SRCML_OPTION_STORE_ENCODING = 1 << 26;
+            public static const ulong SRCML_OPTION_DEFAULT = (SRCML_OPTION_ARCHIVE | SRCML_OPTION_XML_DECL | SRCML_OPTION_NAMESPACE_DECL | SRCML_OPTION_HASH | SRCML_OPTION_PSEUDO_BLOCK | SRCML_OPTION_TERNARY);
+        }
         [StructLayout(LayoutKind.Sequential, Pack=1)]
         public struct ArchiveAdapter {
-            //[MarshalAs(UnmanagedType.U1);
             private IntPtr encoding;
             private IntPtr src_encoding;
             private IntPtr revision;
@@ -18,6 +74,7 @@ namespace ABB.SrcML {
             private IntPtr timestamp;
             private IntPtr hash;
             private int tabstop;
+
             /// <summary>
             /// Sets the encoding for source code
             /// </summary>
@@ -61,7 +118,7 @@ namespace ABB.SrcML {
                 version = Marshal.StringToHGlobalAnsi(srcVersion);
             }
             /// <summary>
-            /// TODO
+            /// Sets the tabstop for the archive
             /// </summary>
             /// <param name="srctab"></param>
             public void SetArchiveTabstop(int srctab) {
@@ -78,19 +135,63 @@ namespace ABB.SrcML {
             /// TODO
             /// </summary>
             /// <param name="srcHash"></param>
-            public void srcml_set_hash(string srcHash) {
+            public void SetHash(string srcHash) {
                 hash = Marshal.StringToHGlobalAnsi(srcHash);
             }
-            void srcml_set_options(long option) {
+            /// <summary>
+            /// Set an option to be used by the parser on the archive
+            /// </summary>
+            /// <param name="option"></param>
+            void SetOptions(long option) {
                 //To be implemented
             }
-            //int srcml_disable_option            (long option);
-            //int srcml_set_tabstop               (int tabstop);
-            //int srcml_register_file_extension   (string  extension, string language);
-            //int srcml_register_namespace        (string  prefix, string ns);
-            //int srcml_set_processing_instruction(string  target, string data); 
-            //int srcml_register_macro            (string  token, string type);
-            //int srcml_unparse_set_eol           (int eol);
+            /// <summary>
+            /// Disable an option
+            /// </summary>
+            /// <param name="option"></param>
+            void DisableOption(long option) {
+                //To be implemented
+            }
+            /// <summary>
+            /// Register a file extension to be used with a particular language
+            /// </summary>
+            /// <param name="extension">The extension string (IE; cpp, cs, java)</param>
+            /// <param name="language">Language attributed with extension (IE; C++, C#, Java)</param>
+            void RegisterFileExtension(string extension, string language) {
+                //To be implemented
+            }
+            /// <summary>
+            /// Create your own namespace; you may need to do this if you add your own custom tags to srcML archives.
+            /// You can also modify known namespaces (like src) to be something else.
+            /// </summary>
+            /// <param name="prefix"></param>
+            /// <param name="ns"></param>
+            void RegisterNamespace(string prefix, string ns) {
+                //To be implemented
+            }
+            /// <summary>
+            /// Todo (I'm not sure what this function does yet)
+            /// </summary>
+            /// <param name="target"></param>
+            /// <param name="data"></param>
+            void SetProcessingInstruction(string target, string data) {
+                //To be implemented
+            }
+            /// <summary>
+            /// Register a macro so that srcML recognizes it when it finds it in the source code to be parsed to srcML
+            /// </summary>
+            /// <param name="token"></param>
+            /// <param name="type"></param>
+            void RegisterMacro(string token, string type) {
+                //To be implemented
+            }
+            /// <summary>
+            /// Set end of line marker
+            /// </summary>
+            /// <param name="eol"></param>
+            void UnparseSetEol(int eol) {
+                //To be implemented
+            }
         }
         public static IntPtr CreatePtrFromStruct(SrcMLCppAPI.ArchiveAdapter ad) {
             int size = Marshal.SizeOf(ad);

--- a/SrcMLCppAPI/SrcMLCppAPI.cpp
+++ b/SrcMLCppAPI/SrcMLCppAPI.cpp
@@ -9,7 +9,7 @@ using namespace System::Runtime::InteropServices;
 
 extern"C"{
     /// <summary>
-    /// This creates an archive from a list of files
+    /// This creates an archive from a list of files and saves to a file
     /// </summary>
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
@@ -21,10 +21,10 @@ extern"C"{
         String^ clistr = gcnew String(ad->encoding);
         String^ clistr2 = gcnew String(ad->filename);
         Console::WriteLine("AD'S ENCODING IS: {0} and file name is: {1}", clistr, clistr2);
-        /* create a new srcml archive structure */
+        /*create a new srcml archive structure */
         archive = srcml_archive_create();
 
-        /* open a srcML archive for output */
+        /*open a srcML archive for output */
         srcml_archive_write_open_filename(archive, outputFile, 0);
 
         /* add all the files to the archive */
@@ -33,24 +33,30 @@ extern"C"{
 
             srcml_unit_set_filename(unit, argv[i]);
 
-            /* Translate to srcml and append to the archive */
+            /*Translate to srcml and append to the archive */
             srcml_unit_parse_filename(unit, argv[i]);
 
-            /* Translate to srcml and append to the archive */
+            /*Translate to srcml and append to the archive */
             srcml_write_unit(archive, unit);
 
             srcml_unit_free(unit);
         }
 
-        /* close the srcML archive */
+        /*close the srcML archive */
         srcml_archive_close(archive);
 
-        /* free the srcML archive data */
+        /*free the srcML archive data */
         srcml_archive_free(archive);
 
         //Return 0 to say it worked-- need to do error checking still for when srcml returns an issue.
         return 0;
     }
+    /// <summary>
+    /// This creates an archive from a buffer and saves to a file 
+    /// </summary>
+    ///<param name="argv">List of files to be read</param>
+    ///<param name="argc">Number of arguments in argv</param>
+    ///<param name="outputFile">File to output to</param>
     __declspec(dllexport) int SrcmlCreateArchiveMtF(char* argv, int argc, const char* outputFile, ArchiveAdapter* ad){
         int i;
         struct srcml_archive* archive;
@@ -87,7 +93,7 @@ extern"C"{
         return 0;
     }
     /// <summary>
-    /// This creates an archive from a file and returns the resulting srcML as a string
+    /// This creates an archive from a file and returns the resulting srcML in a buffer
     /// </summary>
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
@@ -136,7 +142,7 @@ extern"C"{
     }
 
     /// <summary>
-    /// This creates an archive from a buffer and returns the resulting srcML as a string
+    /// This creates an archive from a buffer and returns the resulting srcML in a buffer
     /// </summary>
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>

--- a/SrcMLCppAPI/SrcMLCppAPI.cpp
+++ b/SrcMLCppAPI/SrcMLCppAPI.cpp
@@ -8,17 +8,54 @@ using namespace System;
 using namespace System::Runtime::InteropServices;
 
 extern"C"{
-	/// <summary>
-	/// This creates an archive from a list of files
-	/// </summary>
-	///<param name="argv">List of files to be read</param>
-	///<param name="argc">Number of arguments in argv</param>
-	///<param name="outputFile">File to output to</param>
-	__declspec(dllexport) int SrcmlCreateArchiveFromListOfFiles(char** argv, int argc, const char* outputFile){
+    /// <summary>
+    /// This creates an archive from a list of files
+    /// </summary>
+    ///<param name="argv">List of files to be read</param>
+    ///<param name="argc">Number of arguments in argv</param>
+    ///<param name="outputFile">File to output to</param>
+    __declspec(dllexport) int SrcmlCreateArchiveFtF(char** argv, int argc, const char* outputFile, ArchiveAdapter* ad){
+        int i;
+        struct srcml_archive* archive;
+        struct srcml_unit* unit;
+		String^ clistr = gcnew String(ad->encoding);
+		String^ clistr2 = gcnew String(ad->filename);
+		Console::WriteLine("AD'S ENCODING IS: {0} and file name is: {1}", clistr, clistr2);
+        /* create a new srcml archive structure */
+        archive = srcml_archive_create();
+
+        /* open a srcML archive for output */
+        srcml_archive_write_open_filename(archive, outputFile, 0);
+
+        /* add all the files to the archive */
+        for (i = 0; i < argc; ++i) {
+            unit = srcml_unit_create(archive);
+
+            srcml_unit_set_filename(unit, argv[i]);
+
+            /* Translate to srcml and append to the archive */
+            srcml_unit_parse_filename(unit, argv[i]);
+
+            /* Translate to srcml and append to the archive */
+            srcml_write_unit(archive, unit);
+
+            srcml_unit_free(unit);
+        }
+
+        /* close the srcML archive */
+        srcml_archive_close(archive);
+
+        /* free the srcML archive data */
+        srcml_archive_free(archive);
+
+        //Return 0 to say it worked-- need to do error checking still for when srcml returns an issue.
+        return 0;
+    }
+	__declspec(dllexport) int SrcmlCreateArchiveMtF(char* argv, int argc, const char* outputFile, ArchiveAdapter* ad){
 		int i;
 		struct srcml_archive* archive;
 		struct srcml_unit* unit;
-		
+
 		/* create a new srcml archive structure */
 		archive = srcml_archive_create();
 
@@ -26,19 +63,19 @@ extern"C"{
 		srcml_archive_write_open_filename(archive, outputFile, 0);
 
 		/* add all the files to the archive */
-		for (i = 0; i < argc; ++i) {
-			unit = srcml_unit_create(archive);
+		unit = srcml_unit_create(archive);
 
-			srcml_unit_set_filename(unit, argv[i]);
+		srcml_unit_set_filename(unit, "input.cpp");
 
-			/* Translate to srcml and append to the archive */
-			srcml_unit_parse_filename(unit, argv[i]);
+		/*Set language*/
+		srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);
 
-			/* Translate to srcml and append to the archive */
-			srcml_write_unit(archive, unit);
+		/*Parse*/
+		srcml_unit_parse_memory(unit, argv, argc);
 
-			srcml_unit_free(unit);
-		}
+		/* Translate to srcml and append to the archive */
+		srcml_write_unit(archive, unit);
+		srcml_unit_free(unit);
 
 		/* close the srcML archive */
 		srcml_archive_close(archive);
@@ -49,12 +86,61 @@ extern"C"{
 		//Return 0 to say it worked-- need to do error checking still for when srcml returns an issue.
 		return 0;
 	}
+    /// <summary>
+    /// This creates an archive from a file and returns the resulting srcML as a string
+    /// </summary>
+    ///<param name="argv">List of files to be read</param>
+    ///<param name="argc">Number of arguments in argv</param>
+	__declspec(dllexport) char* SrcmlCreateArchiveFtM(char** argv, int argc, ArchiveAdapter* ad){
+        int i;
+        struct srcml_archive* archive;
+        struct srcml_unit* unit;
+        char * s;
+        size_t size;
+
+        /* create a new srcml archive structure */
+        archive = srcml_archive_create();
+
+        /* open a srcML archive for output */
+        srcml_archive_write_open_memory(archive, &s, &size);
+
+        /* add all the files to the archive */
+        for (i = 0; i < argc; ++i) {
+
+            unit = srcml_unit_create(archive);
+            
+            //Read file into pair of c-string and size of the file. TODO: Error check
+            std::pair<char*, std::streamoff> bufferPair = ReadFileC(argv[i]);
+
+            srcml_unit_set_language(unit, srcml_archive_check_extension(archive, argv[i]));
+
+            srcml_unit_parse_memory(unit, bufferPair.first, bufferPair.second);
+
+            /* Translate to srcml and append to the archive */
+            srcml_write_unit(archive, unit);
+
+            srcml_unit_free(unit);
+
+            delete[] bufferPair.first;
+        }
+
+        /* close the srcML archive */
+        srcml_archive_close(archive);
+
+        /* free the srcML archive data */
+        srcml_archive_free(archive);
+
+        /*Trim any garbage data from the end of the string. TODO: Error check*/
+        TrimFromEnd(s, size);
+        return s;
+    }
+
 	/// <summary>
-	/// This creates an archive from a file and returns the resulting srcML as a string
+	/// This creates an archive from a buffer and returns the resulting srcML as a string
 	/// </summary>
 	///<param name="argv">List of files to be read</param>
 	///<param name="argc">Number of arguments in argv</param>
-	__declspec(dllexport)char* SrcmlCreateArchiveInMemory(char** argv, int argc){
+	__declspec(dllexport) char* SrcmlCreateArchiveMtM(char* argv, int argc, ArchiveAdapter* ad){
 		int i;
 		struct srcml_archive* archive;
 		struct srcml_unit* unit;
@@ -66,26 +152,17 @@ extern"C"{
 
 		/* open a srcML archive for output */
 		srcml_archive_write_open_memory(archive, &s, &size);
+		unit = srcml_unit_create(archive);
 
-		/* add all the files to the archive */
-		for (i = 0; i < argc; ++i) {
+		/*Set language*/
+		srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);
 
-			unit = srcml_unit_create(archive);
-			
-			//Read file into pair of c-string and size of the file. TODO: Error check
-			std::pair<char*, std::streamoff> bufferPair = ReadFileC(argv[i]);
+		/*Parse*/
+		srcml_unit_parse_memory(unit, argv, argc);
 
-			srcml_unit_set_language(unit, srcml_archive_check_extension(archive, argv[i]));
-
-			srcml_unit_parse_memory(unit, bufferPair.first, bufferPair.second);
-
-			/* Translate to srcml and append to the archive */
-			srcml_write_unit(archive, unit);
-
-			srcml_unit_free(unit);
-
-			delete[] bufferPair.first;
-		}
+		/* Translate to srcml and append to the archive */
+		srcml_write_unit(archive, unit);
+		srcml_unit_free(unit);
 
 		/* close the srcML archive */
 		srcml_archive_close(archive);

--- a/SrcMLCppAPI/SrcMLCppAPI.cpp
+++ b/SrcMLCppAPI/SrcMLCppAPI.cpp
@@ -18,9 +18,9 @@ extern"C"{
         int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;
-		String^ clistr = gcnew String(ad->encoding);
-		String^ clistr2 = gcnew String(ad->filename);
-		Console::WriteLine("AD'S ENCODING IS: {0} and file name is: {1}", clistr, clistr2);
+        String^ clistr = gcnew String(ad->encoding);
+        String^ clistr2 = gcnew String(ad->filename);
+        Console::WriteLine("AD'S ENCODING IS: {0} and file name is: {1}", clistr, clistr2);
         /* create a new srcml archive structure */
         archive = srcml_archive_create();
 
@@ -51,47 +51,47 @@ extern"C"{
         //Return 0 to say it worked-- need to do error checking still for when srcml returns an issue.
         return 0;
     }
-	__declspec(dllexport) int SrcmlCreateArchiveMtF(char* argv, int argc, const char* outputFile, ArchiveAdapter* ad){
-		int i;
-		struct srcml_archive* archive;
-		struct srcml_unit* unit;
+    __declspec(dllexport) int SrcmlCreateArchiveMtF(char* argv, int argc, const char* outputFile, ArchiveAdapter* ad){
+        int i;
+        struct srcml_archive* archive;
+        struct srcml_unit* unit;
 
-		/* create a new srcml archive structure */
-		archive = srcml_archive_create();
+        /* create a new srcml archive structure */
+        archive = srcml_archive_create();
 
-		/* open a srcML archive for output */
-		srcml_archive_write_open_filename(archive, outputFile, 0);
+        /* open a srcML archive for output */
+        srcml_archive_write_open_filename(archive, outputFile, 0);
 
-		/* add all the files to the archive */
-		unit = srcml_unit_create(archive);
+        /* add all the files to the archive */
+        unit = srcml_unit_create(archive);
 
-		srcml_unit_set_filename(unit, "input.cpp");
+        srcml_unit_set_filename(unit, "input.cpp");
 
-		/*Set language*/
-		srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);
+        /*Set language*/
+        srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);
 
-		/*Parse*/
-		srcml_unit_parse_memory(unit, argv, argc);
+        /*Parse*/
+        srcml_unit_parse_memory(unit, argv, argc);
 
-		/* Translate to srcml and append to the archive */
-		srcml_write_unit(archive, unit);
-		srcml_unit_free(unit);
+        /* Translate to srcml and append to the archive */
+        srcml_write_unit(archive, unit);
+        srcml_unit_free(unit);
 
-		/* close the srcML archive */
-		srcml_archive_close(archive);
+        /* close the srcML archive */
+        srcml_archive_close(archive);
 
-		/* free the srcML archive data */
-		srcml_archive_free(archive);
+        /* free the srcML archive data */
+        srcml_archive_free(archive);
 
-		//Return 0 to say it worked-- need to do error checking still for when srcml returns an issue.
-		return 0;
-	}
+        //Return 0 to say it worked-- need to do error checking still for when srcml returns an issue.
+        return 0;
+    }
     /// <summary>
     /// This creates an archive from a file and returns the resulting srcML as a string
     /// </summary>
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
-	__declspec(dllexport) char* SrcmlCreateArchiveFtM(char** argv, int argc, ArchiveAdapter* ad){
+    __declspec(dllexport) char* SrcmlCreateArchiveFtM(char** argv, int argc, ArchiveAdapter* ad){
         int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;
@@ -135,43 +135,43 @@ extern"C"{
         return s;
     }
 
-	/// <summary>
-	/// This creates an archive from a buffer and returns the resulting srcML as a string
-	/// </summary>
-	///<param name="argv">List of files to be read</param>
-	///<param name="argc">Number of arguments in argv</param>
-	__declspec(dllexport) char* SrcmlCreateArchiveMtM(char* argv, int argc, ArchiveAdapter* ad){
-		int i;
-		struct srcml_archive* archive;
-		struct srcml_unit* unit;
-		char * s;
-		size_t size;
+    /// <summary>
+    /// This creates an archive from a buffer and returns the resulting srcML as a string
+    /// </summary>
+    ///<param name="argv">List of files to be read</param>
+    ///<param name="argc">Number of arguments in argv</param>
+    __declspec(dllexport) char* SrcmlCreateArchiveMtM(char* argv, int argc, ArchiveAdapter* ad){
+        int i;
+        struct srcml_archive* archive;
+        struct srcml_unit* unit;
+        char * s;
+        size_t size;
 
-		/* create a new srcml archive structure */
-		archive = srcml_archive_create();
+        /* create a new srcml archive structure */
+        archive = srcml_archive_create();
 
-		/* open a srcML archive for output */
-		srcml_archive_write_open_memory(archive, &s, &size);
-		unit = srcml_unit_create(archive);
+        /* open a srcML archive for output */
+        srcml_archive_write_open_memory(archive, &s, &size);
+        unit = srcml_unit_create(archive);
 
-		/*Set language*/
-		srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);
+        /*Set language*/
+        srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);
 
-		/*Parse*/
-		srcml_unit_parse_memory(unit, argv, argc);
+        /*Parse*/
+        srcml_unit_parse_memory(unit, argv, argc);
 
-		/* Translate to srcml and append to the archive */
-		srcml_write_unit(archive, unit);
-		srcml_unit_free(unit);
+        /* Translate to srcml and append to the archive */
+        srcml_write_unit(archive, unit);
+        srcml_unit_free(unit);
 
-		/* close the srcML archive */
-		srcml_archive_close(archive);
+        /* close the srcML archive */
+        srcml_archive_close(archive);
 
-		/* free the srcML archive data */
-		srcml_archive_free(archive);
+        /* free the srcML archive data */
+        srcml_archive_free(archive);
 
-		/*Trim any garbage data from the end of the string. TODO: Error check*/
-		TrimFromEnd(s, size);
-		return s;
-	}
+        /*Trim any garbage data from the end of the string. TODO: Error check*/
+        TrimFromEnd(s, size);
+        return s;
+    }
 }

--- a/SrcMLCppAPI/SrcMLCppAPI.h
+++ b/SrcMLCppAPI/SrcMLCppAPI.h
@@ -3,16 +3,16 @@
 using namespace System;
 using namespace System::Runtime::InteropServices;
 public struct ArchiveAdapter {
-	char* encoding;
-	char* src_encoding;
-	char* revision;
-	char* language;
-	char* filename;
-	char* url;
-	char* version;
-	char* timestamp;
-	char* hash;
-	int tabstop;
+    char* encoding;
+    char* src_encoding;
+    char* revision;
+    char* language;
+    char* filename;
+    char* url;
+    char* version;
+    char* timestamp;
+    char* hash;
+    int tabstop;
 };
 /// <summary>
 /// Utility function that trims from the right of a string. For now it's just solving a weird issue with srcML

--- a/SrcMLCppAPI/SrcMLCppAPI.h
+++ b/SrcMLCppAPI/SrcMLCppAPI.h
@@ -2,54 +2,66 @@
 #include <fstream>
 using namespace System;
 using namespace System::Runtime::InteropServices;
+public struct ArchiveAdapter {
+	char* encoding;
+	char* src_encoding;
+	char* revision;
+	char* language;
+	char* filename;
+	char* url;
+	char* version;
+	char* timestamp;
+	char* hash;
+	int tabstop;
+};
 /// <summary>
 /// Utility function that trims from the right of a string. For now it's just solving a weird issue with srcML
 /// and garbage text ending up at the end of the cstring it returns.
 /// </summary>
 char* TrimFromEnd(char *s, size_t len){
-	for (int i = len - 1; i > 0; --i){
-		if (s[i] != '>'){
-			s[i] = 0;
-		}
-		else{
-			return s;
-		}
-	}
-	return nullptr;
+    for (int i = len - 1; i > 0; --i){
+        if (s[i] != '>'){
+            s[i] = 0;
+        }
+        else{
+            return s;
+        }
+    }
+    return nullptr;
 }
 /// <summary>
 /// Utility function that is meant to Read a file from beginning to end.
 /// </summary>
 /// <param name="argv">The name of the file to be read.</param>
 std::pair<char*, std::streamoff> ReadFileC(const char* argv){
-	std::ifstream is(argv, std::ifstream::binary);
-	char * buffer = nullptr;
-	std::streamoff length;
-	if (is) {
-		// get length of file:
-		is.seekg(0, is.end);
-		length = is.tellg();
-		is.seekg(0, is.beg);
+    std::ifstream is(argv, std::ifstream::binary);
+    char * buffer = nullptr;
+    std::streamoff length;
+    if (is) {
+        // get length of file:
+        is.seekg(0, is.end);
+        length = is.tellg();
+        is.seekg(0, is.beg);
 
-		// allocate memory:
-		char * buffer = new char[length + 1];
+        // allocate memory:
+        char * buffer = new char[length + 1];
 
-		// read data as a block:
-		is.read(buffer, length);
+        // read data as a block:
+        is.read(buffer, length);
 
-		//add and account for null
-		buffer[length] = '\0';
-		++length;
+        //add and account for null
+        buffer[length] = '\0';
+        ++length;
 
-		is.close();
+        is.close();
 
-		return std::make_pair(buffer, length);
-	}
-	else{
-		//Should do something here. Either error and quit or exception and handle?
-		String^ clistr = gcnew String(argv);
-		Console::WriteLine("ERROR, could not open file: {0}", clistr);
-		throw std::exception("Couldn't open file");
-	}
+        return std::make_pair(buffer, length);
+    }
+    else{
+        //Should do something here. Either error and quit or exception and handle?
+        String^ clistr = gcnew String(argv);
+        Console::WriteLine("ERROR, could not open file: {0}", clistr);
+        throw std::exception("Couldn't open file");
+    }
 
 }


### PR DESCRIPTION
With this, we should have a reasonable foundation for the API. An adapter class has been added to C# to mimic C++'s srcML archive. These are translated from C# to C++ during runtime. Most methods required by the adapter have been added (but not all implemented yet).

Also we now have four methods that create archives; One reads from files and writes to a file (SrcmlCreateArchiveFtF), the next reads from memory and writes to file (SrcmlCreateArchiveMtF), the next reads from a file and writes to memory (SrcmlCreateArchiveFtM) and the last reads from memory and writes to memory (SrcmlCreateArchiveMtM). 

Conceivably, the next step is to make changes so that unit tests can be properly written before more implementing of the interface is done.