### PR TITLE
Upgrade to srcML 1.0 - Groundwork update 2

### DIFF
--- a/ABB.SrcML.Test/SrcMLCppAPITests.cs
+++ b/ABB.SrcML.Test/SrcMLCppAPITests.cs
@@ -15,8 +15,7 @@ namespace ABB.SrcML.Test {
     [Category("Build")]
     class SrcMLCppAPITests {
         /// <summary>
-        /// This tests the creation of an archive called 'output.cpp.xml' using a list of source files
-        /// from which the archive will be derived.
+        /// This tests the creation of an archive using a list of source files
         /// </summary>
         [Test]
         public void TestCreateSrcMLArchiveFtF() {
@@ -32,38 +31,50 @@ namespace ABB.SrcML.Test {
             data.Add(ad);
             data.Add(bc);
 
-            IntPtr ptr = SrcMLCppAPI.CreatePtrFromStruct(ad);
-            IntPtr ptr2 = SrcMLCppAPI.CreatePtrFromStruct(bc);
+            IntPtr structPtr = SrcMLCppAPI.CreatePtrFromStruct(ad);
+            IntPtr structPtr2 = SrcMLCppAPI.CreatePtrFromStruct(bc);
 
-            List<IntPtr> ptrptr = new List<IntPtr>();
-            ptrptr.Add(ptr);
-            ptrptr.Add(ptr2);
+            List<IntPtr> structArrayPtr = new List<IntPtr>();
+            structArrayPtr.Add(structPtr);
+            structArrayPtr.Add(structPtr2);
 
-            Assert.True(SrcMLCppAPI.SrcmlCreateArchiveFtF(ptrptr.ToArray(), ptrptr.Count(), "output.cpp.xml") == 0);
-            Assert.True(File.Exists("output.cpp.xml"));
+            Assert.True(SrcMLCppAPI.SrcmlCreateArchiveFtF(structArrayPtr.ToArray(), structArrayPtr.Count(), "output") == 0);
+            
 
-            SrcMLFile srcFile = new SrcMLFile("output.cpp.xml");
-            Assert.IsNotNull(srcFile);
+            {
+                Assert.True(File.Exists("output0.cpp.xml"));
+                SrcMLFile srcFile = new SrcMLFile("output0.cpp.xml");
+                Assert.IsNotNull(srcFile);
 
-            var files = srcFile.FileUnits.ToList();
-            Assert.AreEqual(2, files.Count());
+                var files = srcFile.FileUnits.ToList();
+                Assert.AreEqual(1, files.Count());
 
-            string file = "input.cpp";
-            var f1 = (from ele in files
-                      where ele.Attribute("filename").Value == file
-                      select ele);
-            Assert.AreEqual("input.cpp", f1.FirstOrDefault().Attribute("filename").Value);
+                string file = "input.cpp";
+                var f1 = (from ele in files
+                          where ele.Attribute("filename").Value == file
+                          select ele);
+                Assert.AreEqual("input.cpp", f1.FirstOrDefault().Attribute("filename").Value);
+            }
+            {
+                Assert.True(File.Exists("output1.cpp.xml"));
+                SrcMLFile srcFile = new SrcMLFile("output1.cpp.xml");
+                Assert.IsNotNull(srcFile);
 
-            string file1 = "input2.cpp";
-            var f2 = (from ele in files
-                      where ele.Attribute("filename").Value == file1
-                      select ele);
-            Assert.AreEqual("input2.cpp", f2.FirstOrDefault().Attribute("filename").Value);
+                var files = srcFile.FileUnits.ToList();
+                Assert.AreEqual(1, files.Count());
+
+                string file1 = "input2.cpp";
+                var f2 = (from ele in files
+                          where ele.Attribute("filename").Value == file1
+                          select ele);
+                Assert.AreEqual("input2.cpp", f2.FirstOrDefault().Attribute("filename").Value);
+            }
+            ad.Dispose();
+            bc.Dispose();
         }
-        /// TODO: This requires some modifications to be made to SrcMLFile so that it can take strings of xml. Going to do
-        /// A pull of what I have so far before I go making those kinds of changes.
+
         /// <summary>
-        /// Tests the creation of srcML to be returned as a string instead of being placed in af file.
+        /// Tests the creation of srcML from a file and returned via string
         /// </summary>
         [Test]
         public void TestCreateSrcMLArchiveFtM() {
@@ -79,14 +90,14 @@ namespace ABB.SrcML.Test {
             data.Add(ad);
             data.Add(bc);
 
-            IntPtr ptr = SrcMLCppAPI.CreatePtrFromStruct(ad);
-            IntPtr ptr2 = SrcMLCppAPI.CreatePtrFromStruct(bc);
+            IntPtr structPtr = SrcMLCppAPI.CreatePtrFromStruct(ad);
+            IntPtr structPtr2 = SrcMLCppAPI.CreatePtrFromStruct(bc);
 
-            List<IntPtr> ptrptr = new List<IntPtr>();
-            ptrptr.Add(ptr);
-            ptrptr.Add(ptr2);
+            List<IntPtr> structArrayPtr = new List<IntPtr>();
+            structArrayPtr.Add(structPtr);
+            structArrayPtr.Add(structPtr2);
 
-            string s = SrcMLCppAPI.SrcmlCreateArchiveFtM(ptrptr.ToArray(), ptrptr.Count());
+            string s = SrcMLCppAPI.SrcmlCreateArchiveFtM(structArrayPtr.ToArray(), structArrayPtr.Count());
 
             Assert.False(String.IsNullOrEmpty(s));
             XDocument doc = XDocument.Parse(s);
@@ -108,41 +119,42 @@ namespace ABB.SrcML.Test {
 
             //XmlReader reader = XmlReader.Create(new StringReader(s));
             Console.WriteLine(s);
+
+            ad.Dispose();
+            bc.Dispose();
         }
-        /// TODO: This requires some modifications to be made to SrcMLFile so that it can take strings of xml. Going to do
-        /// A pull of what I have so far before I go making those kinds of changes.
+
         /// <summary>
-        /// Tests the creation of srcML to be returned as a string instead of being placed in af file.
+        /// Tests the creation of srcML from code in memory and placed in a file
         /// </summary>
         [Test]
         public void TestCreateSrcMLArchiveMtF() {
             SrcMLCppAPI.SourceData ad = new SrcMLCppAPI.SourceData();
 
-            List<String> fileL = new List<String>();
-            List<String> fileL2 = new List<String>();
+            List<String> BufferList = new List<String>();
+            List<String> FileList = new List<String>();
             String str = "int main(){int c; c = 0; ++c;}";
             String str2 = "int foo(){int c; c = 0; ++c;}";
-            fileL.Add(str);
-            fileL.Add(str2);
-            ad.SetArchiveBuffer(fileL);
+            BufferList.Add(str);
+            BufferList.Add(str2);
+            ad.SetArchiveBuffer(BufferList);
 
             
-            fileL2.Add("input.cpp");
-            fileL2.Add("input2.cpp");
-            ad.SetArchiveFilename(fileL2);
+            FileList.Add("input.cpp");
+            FileList.Add("input2.cpp");
+            ad.SetArchiveFilename(FileList);
 
             ad.SetArchiveLanguage(SrcMLCppAPI.SrcMLOptions.SRCML_LANGUAGE_CXX);
 
-            IntPtr ptr = SrcMLCppAPI.CreatePtrFromStruct(ad);
+            IntPtr structPtr = SrcMLCppAPI.CreatePtrFromStruct(ad);
 
-            List<IntPtr> ptrptr = new List<IntPtr>();
-            ptrptr.Add(ptr);
+            List<IntPtr> structArrayPtr = new List<IntPtr>();
+            structArrayPtr.Add(structPtr);
 
-            //Console.WriteLine("check: {0}", Marshal.PtrToStringAnsi(ad.buffer[0]));
-            Assert.True(SrcMLCppAPI.SrcmlCreateArchiveMtF(ptrptr.ToArray(), ptrptr.Count(), "test.xml") == 0);
-            Assert.True(File.Exists("test.xml"));
+            Assert.True(SrcMLCppAPI.SrcmlCreateArchiveMtF(structArrayPtr.ToArray(), structArrayPtr.Count(), "test") == 0);
+            Assert.True(File.Exists("test0.cpp.xml"));
             
-            SrcMLFile srcFile = new SrcMLFile("test.xml");
+            SrcMLFile srcFile = new SrcMLFile("test0.cpp.xml");
             Assert.IsNotNull(srcFile);
 
             var files = srcFile.FileUnits.ToList();
@@ -159,38 +171,38 @@ namespace ABB.SrcML.Test {
                       where ele.Attribute("filename").Value == file2
                       select ele);
             Assert.AreEqual("input.cpp", f1.FirstOrDefault().Attribute("filename").Value);
-            
+
+            ad.Dispose();
         }
-        /// TODO: This requires some modifications to be made to SrcMLFile so that it can take strings of xml. Going to do
-        /// A pull of what I have so far before I go making those kinds of changes.
+
         /// <summary>
-        /// Tests the creation of srcML to be returned as a string instead of being placed in af file.
+        /// Tests the creation of srcML from code in memory and returned as a string
         /// </summary>
         [Test]
         public void TestCreateSrcMLArchiveMtM() {
             SrcMLCppAPI.SourceData ad = new SrcMLCppAPI.SourceData();
 
-            List<String> fileL = new List<String>();
-            List<String> fileL2 = new List<String>();
+            List<String> BufferList = new List<String>();
+            List<String> FileList = new List<String>();
             String str = "int main(){int c; c = 0; ++c;}";
             String str2 = "int foo(){int c; c = 0; ++c;}";
-            fileL.Add(str);
-            fileL.Add(str2);
-            ad.SetArchiveBuffer(fileL);
+            BufferList.Add(str);
+            BufferList.Add(str2);
+            ad.SetArchiveBuffer(BufferList);
 
 
-            fileL2.Add("input.cpp");
-            fileL2.Add("input2.cpp");
-            ad.SetArchiveFilename(fileL2);
+            FileList.Add("input.cpp");
+            FileList.Add("input2.cpp");
+            ad.SetArchiveFilename(FileList);
 
             ad.SetArchiveLanguage(SrcMLCppAPI.SrcMLOptions.SRCML_LANGUAGE_CXX);
 
-            IntPtr ptr = SrcMLCppAPI.CreatePtrFromStruct(ad);
+            IntPtr structPtr = SrcMLCppAPI.CreatePtrFromStruct(ad);
 
-            List<IntPtr> ptrptr = new List<IntPtr>();
-            ptrptr.Add(ptr);
+            List<IntPtr> structArrayPtr = new List<IntPtr>();
+            structArrayPtr.Add(structPtr);
 
-            string s = SrcMLCppAPI.SrcmlCreateArchiveMtM(ptrptr.ToArray(), ptrptr.Count());
+            string s = SrcMLCppAPI.SrcmlCreateArchiveMtM(structArrayPtr.ToArray(), structArrayPtr.Count());
 
             Assert.False(String.IsNullOrEmpty(s));
             XDocument doc = XDocument.Parse(s);
@@ -210,7 +222,8 @@ namespace ABB.SrcML.Test {
                       select ele);
             Assert.AreEqual("input2.cpp", f2.FirstOrDefault().Attribute("filename").Value);
             Console.WriteLine(s);
+            ad.Dispose();
         }
-
+      
     }
 }

--- a/ABB.SrcML.Test/SrcMLCppAPITests.cs
+++ b/ABB.SrcML.Test/SrcMLCppAPITests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using ABB.SrcML;
 using System.Xml;
 using System.Runtime.InteropServices;
+using System.Xml.Linq;
 
 namespace ABB.SrcML.Test {
 
@@ -64,6 +65,23 @@ namespace ABB.SrcML.Test {
             IntPtr ptr = SrcMLCppAPI.CreatePtrFromStruct(ad);
             string s = SrcMLCppAPI.SrcmlCreateArchiveFtM(l.ToArray(), l.Count(), ptr);
             Assert.False(String.IsNullOrEmpty(s));
+            XDocument doc = XDocument.Parse(s);
+            var units = from unit in doc.Descendants(XName.Get("unit", "http://www.srcML.org/srcML/src"))
+                       where unit.Attribute("filename") != null
+                       select unit;
+                
+            string file = "input.cpp";
+            var f1 = (from ele in units
+                      where ele.Attribute("filename").Value == file
+                      select ele);
+            Assert.AreEqual("input.cpp", f1.FirstOrDefault().Attribute("filename").Value);
+
+            string file2 = "input2.cpp";
+            var f2 = (from ele in units
+                      where ele.Attribute("filename").Value == file2
+                      select ele);
+            Assert.AreEqual("input2.cpp", f2.FirstOrDefault().Attribute("filename").Value);
+
             //XmlReader reader = XmlReader.Create(new StringReader(s));
             Console.WriteLine(s);
         }
@@ -77,6 +95,7 @@ namespace ABB.SrcML.Test {
             String str = "int main(){int c; c = 0; ++c;}";
 
             SrcMLCppAPI.ArchiveAdapter ad = new SrcMLCppAPI.ArchiveAdapter();
+            ad.SetArchiveFilename("input.cpp");
             IntPtr ptr = SrcMLCppAPI.CreatePtrFromStruct(ad);
 
             Assert.True(SrcMLCppAPI.SrcmlCreateArchiveMtF(str, str.Length, "output.cpp.xml", ptr) == 0);
@@ -108,11 +127,21 @@ namespace ABB.SrcML.Test {
             String str = "int main(){int c; c = 0; ++c;}";
 
             SrcMLCppAPI.ArchiveAdapter ad = new SrcMLCppAPI.ArchiveAdapter();
+            ad.SetArchiveFilename("input.cpp");
             IntPtr ptr = SrcMLCppAPI.CreatePtrFromStruct(ad);
 
             string s = SrcMLCppAPI.SrcmlCreateArchiveMtM(str, str.Length, ptr);
             Assert.False(String.IsNullOrEmpty(s));
-            //XmlReader reader = XmlReader.Create(new StringReader(s));
+            XDocument doc = XDocument.Parse(s);
+            var units = from unit in doc.Descendants(XName.Get("unit", "http://www.srcML.org/srcML/src"))
+                        where unit.Attribute("filename") != null
+                        select unit;
+
+            string file = "input.cpp";
+            var f1 = (from ele in units
+                      where ele.Attribute("filename").Value == file
+                      select ele);
+            Assert.AreEqual("input.cpp", f1.FirstOrDefault().Attribute("filename").Value);
             Console.WriteLine(s);
         }
 

--- a/ABB.SrcML/SrcMLCppAPI.cs
+++ b/ABB.SrcML/SrcMLCppAPI.cs
@@ -199,17 +199,17 @@ namespace ABB.SrcML {
             Marshal.StructureToPtr(ad, ptr, false);
             return ptr;
         }
-        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
+        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern int SrcmlCreateArchiveFtF(string[] argv, int argc, string outputFile, IntPtr Adapter);
-        
-        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
+
+        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern int SrcmlCreateArchiveMtF(string argv, int argc, string outputFile, IntPtr Adapter);
-        
-        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
+
+        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.LPStr)]
         public static extern string SrcmlCreateArchiveFtM(string[] argv, int argc, IntPtr Adapter);
-        
-        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.StdCall)]
+
+        [DllImport(@"..\..\External\srcML1.0\bin\SrcMLCppAPI.dll", CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.LPStr)]
         public static extern string SrcmlCreateArchiveMtM(string argv, int argc, IntPtr Adapter);
     }

--- a/ABB.SrcML/SrcMLCppAPI.cs
+++ b/ABB.SrcML/SrcMLCppAPI.cs
@@ -61,7 +61,26 @@ namespace ABB.SrcML {
             /** Encode the original source encoding as an attribute */
             public const ulong SRCML_OPTION_STORE_ENCODING = 1 << 26;
             public const ulong SRCML_OPTION_DEFAULT = (SRCML_OPTION_ARCHIVE | SRCML_OPTION_XML_DECL | SRCML_OPTION_NAMESPACE_DECL | SRCML_OPTION_HASH | SRCML_OPTION_PSEUDO_BLOCK | SRCML_OPTION_TERNARY);
+
+            /* Core language set */
+            /** srcML language not set */
+            public const int SRCML_LANGUAGE_NONE = 0;
+            /** string for language C */
+            public const string SRCML_LANGUAGE_C = "C";
+            /** string for language C++ */
+            public const string  SRCML_LANGUAGE_CXX = "C++";
+            /** string for language Java */
+            public const string  SRCML_LANGUAGE_JAVA = "Java";
+            /** string for language C# */
+            public const string  SRCML_LANGUAGE_CSHARP ="C#";
+            /** string for language C# */
+            public const string  SRCML_LANGUAGE_OBJECTIVE_C = "Objective-C";
+            /** string for language XML */
+            public const string SRCML_LANGUAGE_XML = "xml";
         }
+        /// <summary>
+        /// Carries data between C# and C++ for srcML's archives
+        /// </summary>
         [StructLayout(LayoutKind.Sequential, Pack=1)]
         public struct ArchiveAdapter {
             private IntPtr encoding;

--- a/SrcMLCppAPI/SrcMLCppAPI.cpp
+++ b/SrcMLCppAPI/SrcMLCppAPI.cpp
@@ -4,6 +4,7 @@
 #include "srcml.h"
 #include "SrcMLCppAPI.h"
 #include <iostream>
+#include <string>
 using namespace System;
 using namespace System::Runtime::InteropServices;
 void SetMetaData(srcml_unit* unit, SourceData* archiveData){
@@ -12,8 +13,6 @@ void SetMetaData(srcml_unit* unit, SourceData* archiveData){
     }
 
     if (archiveData->language != ""){
-        String^ clistr = gcnew String(archiveData->language);
-        Console::WriteLine("AD'S LANGUAGE IS: {0}", clistr);
         srcml_unit_set_language(unit, archiveData->language);
         srcml_set_language(archiveData->language);
     }
@@ -51,23 +50,23 @@ extern"C"{
     ///<param name="argc">Number of arguments in argv</param>
     ///<param name="outputFile">File to output to</param>
     __declspec(dllexport) int SrcmlCreateArchiveFtF(SourceData** sd, int argc, const char* outputFile) {
-        int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;		
-
-        /*create a new srcml archive structure */
-        archive = srcml_archive_create();
-
-        /*open a srcML archive for output */
-        srcml_archive_write_open_filename(archive, outputFile, 0);
-        /* add all the files to the archive */
+        
         for (int i = 0; i < argc; ++i){
+            /*create a new srcml archive structure */
+            archive = srcml_archive_create();
+            std::string filename(outputFile);
+            filename += std::to_string(i) + ".cpp.xml";
+            /*open a srcML archive for output */
+            srcml_archive_write_open_filename(archive, filename.c_str(), 0);
+            
+            /* add all the files to the archive */
             for (int k = 0; k < sd[i]->buffercount; ++k) {
                 unit = srcml_unit_create(archive);
 
                 String^ clistr = gcnew String(sd[i]->encoding);
                 String^ clistr2 = gcnew String(sd[i]->filename[k]);
-                Console::WriteLine("AD'S ENCODING IS: {0} and file name is: {1}", clistr, clistr2);
 
                 SetMetaData(unit, sd[i]);
 
@@ -81,14 +80,12 @@ extern"C"{
 
                 srcml_unit_free(unit);
             }
+            /*close the srcML archive */
+            srcml_archive_close(archive);
+
+            /*free the srcML archive data */
+            srcml_archive_free(archive);
         }
-
-
-        /*close the srcML archive */
-        srcml_archive_close(archive);
-
-        /*free the srcML archive data */
-        srcml_archive_free(archive);
 
         //Return 0 to say it worked-- need to do error checking still for when srcml returns an issue.
         return 0;
@@ -105,8 +102,10 @@ extern"C"{
             /* create a new srcml archive structure */
             archive = srcml_archive_create();
             /* open a srcML archive for output */
-            int numRead = 0;
-            srcml_archive_write_open_filename(archive, "test.xml", 0);
+            std::string filename(outputFile);
+            filename += std::to_string(i) + ".cpp.xml";
+            /*open a srcML archive for output */
+            srcml_archive_write_open_filename(archive, filename.c_str(), 0);
             for (int j = 0; j < sd[i]->buffercount; ++j){
                 struct srcml_unit* unit;
                 /* add all the files to the archive */
@@ -184,7 +183,7 @@ extern"C"{
 
         /*Trim any garbage data from the end of the string. TODO: Error check*/
         TrimFromEnd(s, size);
-        return s;
+        return s;//Will return only most recent string; need to fix.
     }
 
     /// <summary>
@@ -223,6 +222,6 @@ extern"C"{
             /*Trim any garbage data from the end of the string. TODO: Error check*/
             TrimFromEnd(s, size);
         }
-        return s;
+        return s; //Will return only most recent string; need to fix.
     }
 }

--- a/SrcMLCppAPI/SrcMLCppAPI.cpp
+++ b/SrcMLCppAPI/SrcMLCppAPI.cpp
@@ -14,7 +14,7 @@ extern"C"{
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
     ///<param name="outputFile">File to output to</param>
-    __declspec(dllexport) int SrcmlCreateArchiveFtF(char** argv, int argc, const char* outputFile, ArchiveAdapter* ad){
+    __declspec(dllexport) int SrcmlCreateArchiveFtF(char** argv, int argc, const char* outputFile, ArchiveAdapter* ad) {
         int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;
@@ -57,7 +57,7 @@ extern"C"{
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
     ///<param name="outputFile">File to output to</param>
-    __declspec(dllexport) int SrcmlCreateArchiveMtF(char* argv, int argc, const char* outputFile, ArchiveAdapter* ad){
+    __declspec(dllexport) int SrcmlCreateArchiveMtF(char* argv, int argc, const char* outputFile, ArchiveAdapter* ad) {
         int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;
@@ -71,7 +71,7 @@ extern"C"{
         /* add all the files to the archive */
         unit = srcml_unit_create(archive);
 
-        srcml_unit_set_filename(unit, "input.cpp");
+        srcml_unit_set_filename(unit, ad->filename);
 
         /*Set language*/
         srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);
@@ -97,7 +97,7 @@ extern"C"{
     /// </summary>
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
-    __declspec(dllexport) char* SrcmlCreateArchiveFtM(char** argv, int argc, ArchiveAdapter* ad){
+    __declspec(dllexport) char* SrcmlCreateArchiveFtM(char** argv, int argc, ArchiveAdapter* ad) {
         int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;
@@ -114,7 +114,8 @@ extern"C"{
         for (i = 0; i < argc; ++i) {
 
             unit = srcml_unit_create(archive);
-            
+
+			srcml_unit_set_filename(unit, argv[i]);
             //Read file into pair of c-string and size of the file. TODO: Error check
             std::pair<char*, std::streamoff> bufferPair = ReadFileC(argv[i]);
 
@@ -146,7 +147,7 @@ extern"C"{
     /// </summary>
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
-    __declspec(dllexport) char* SrcmlCreateArchiveMtM(char* argv, int argc, ArchiveAdapter* ad){
+    __declspec(dllexport) char* SrcmlCreateArchiveMtM(char* argv, int argc, ArchiveAdapter* ad) {
         int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;
@@ -159,6 +160,8 @@ extern"C"{
         /* open a srcML archive for output */
         srcml_archive_write_open_memory(archive, &s, &size);
         unit = srcml_unit_create(archive);
+
+		srcml_unit_set_filename(unit, ad->filename);
 
         /*Set language*/
         srcml_unit_set_language(unit, SRCML_LANGUAGE_CSHARP);

--- a/SrcMLCppAPI/SrcMLCppAPI.cpp
+++ b/SrcMLCppAPI/SrcMLCppAPI.cpp
@@ -3,10 +3,46 @@
 #include "stdafx.h"
 #include "srcml.h"
 #include "SrcMLCppAPI.h"
-
 using namespace System;
 using namespace System::Runtime::InteropServices;
+void SetArchive(ArchiveAdapter* adapterArchive){
+	if (adapterArchive->src_encoding != ""){
+		srcml_set_src_encoding(adapterArchive->src_encoding);
+	}
 
+	if (adapterArchive->filename != ""){
+		srcml_set_filename(adapterArchive->filename);
+	}
+
+	if (adapterArchive->language != ""){
+		srcml_set_language(adapterArchive->language);
+	}
+
+	if (adapterArchive->tabstop != 0){
+		srcml_set_tabstop(adapterArchive->tabstop);
+	}
+
+	if (adapterArchive->url != ""){
+		srcml_set_url(adapterArchive->url);
+	}
+
+	if (adapterArchive->timestamp != ""){
+		srcml_set_timestamp(adapterArchive->timestamp);
+	}
+
+	if (adapterArchive->hash != ""){
+		srcml_set_hash(adapterArchive->hash);
+	}
+
+	if (adapterArchive->version != ""){
+		srcml_set_version(adapterArchive->version);
+	}
+
+	if (adapterArchive->encoding != ""){
+		srcml_set_xml_encoding(adapterArchive->encoding);
+	}
+
+}
 extern"C"{
     /// <summary>
     /// This creates an archive from a list of files and saves to a file
@@ -21,12 +57,14 @@ extern"C"{
         String^ clistr = gcnew String(ad->encoding);
         String^ clistr2 = gcnew String(ad->filename);
         Console::WriteLine("AD'S ENCODING IS: {0} and file name is: {1}", clistr, clistr2);
-        /*create a new srcml archive structure */
+        
+		SetArchive(ad);
+
+		/*create a new srcml archive structure */
         archive = srcml_archive_create();
 
         /*open a srcML archive for output */
         srcml_archive_write_open_filename(archive, outputFile, 0);
-
         /* add all the files to the archive */
         for (i = 0; i < argc; ++i) {
             unit = srcml_unit_create(archive);
@@ -61,6 +99,8 @@ extern"C"{
         int i;
         struct srcml_archive* archive;
         struct srcml_unit* unit;
+
+		SetArchive(ad);
 
         /* create a new srcml archive structure */
         archive = srcml_archive_create();
@@ -103,6 +143,8 @@ extern"C"{
         struct srcml_unit* unit;
         char * s;
         size_t size;
+
+		SetArchive(ad);
 
         /* create a new srcml archive structure */
         archive = srcml_archive_create();
@@ -153,7 +195,7 @@ extern"C"{
         struct srcml_unit* unit;
         char * s;
         size_t size;
-
+		SetArchive(ad);
         /* create a new srcml archive structure */
         archive = srcml_archive_create();
 

--- a/SrcMLCppAPI/SrcMLCppAPI.h
+++ b/SrcMLCppAPI/SrcMLCppAPI.h
@@ -2,16 +2,19 @@
 #include <fstream>
 using namespace System;
 using namespace System::Runtime::InteropServices;
-public struct ArchiveAdapter {
+public struct SourceData {
     char* encoding;
     char* src_encoding;
     char* revision;
     char* language;
-    char* filename;
+    char** filename;
     char* url;
     char* version;
     char* timestamp;
     char* hash;
+    char** buffer;
+    int buffercount;
+    int* buffersize;
     int tabstop;
 };
 /// <summary>
@@ -56,8 +59,7 @@ std::pair<char*, std::streamoff> ReadFileC(const char* argv){
         is.close();
 
         return std::make_pair(buffer, length);
-    }
-    else{
+    }else{
         //Should do something here. Either error and quit or exception and handle?
         String^ clistr = gcnew String(argv);
         Console::WriteLine("ERROR, could not open file: {0}", clistr);


### PR DESCRIPTION
API should fully (or close to fully) support multiple archives and multiple files within archives no matter input/output method (ftm, mtm, ftf, mtf). Updated names for identifiers, added garbage collection for unmanaged resources, and created a way to manually construct 2d arrays in memory so we can pass string arrays around without much headache.