### PR TITLE
Refactoring the DS

### DIFF
--- a/ABB.SrcML.Test/LibSrcMLRunnerTests.cs
+++ b/ABB.SrcML.Test/LibSrcMLRunnerTests.cs
@@ -502,6 +502,7 @@ namespace ABB.SrcML.Test {
         public void TestArchiveDisableOption() {
             using (Archive srcmlarchive = new Archive()) {
                 using (Unit srcmlunit = new Unit()) {
+                    srcmlarchive.SetOptions(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
                     srcmlarchive.DisableOption(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
                     srcmlarchive.AddUnit(srcmlunit);
                     srcmlarchive.ArchivePack();

--- a/ABB.SrcML.Test/LibSrcMLRunnerTests.cs
+++ b/ABB.SrcML.Test/LibSrcMLRunnerTests.cs
@@ -25,20 +25,20 @@ namespace ABB.SrcML.Test {
         /// </summary>
         [Test]
         public void TestCreateSrcMLArchiveFtF() {
-            using (Archive srcmlarchive = new Archive(), srcmlarchive2 = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitFilename(Path.Combine(TestInputPath, "input.cpp"));
-                    srcmlarchive.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
+            using (Archive srcmlArchive = new Archive(), srcmlArchive2 = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitFilename(Path.Combine(TestInputPath, "input.cpp"));
+                    srcmlArchive.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
 
-                    srcmlunit.SetUnitFilename(Path.Combine(TestInputPath, "input2.cpp"));
-                    srcmlarchive2.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                    srcmlarchive2.AddUnit(srcmlunit);
-                    srcmlarchive2.ArchivePack();
+                    srcmlUnit.SetUnitFilename(Path.Combine(TestInputPath, "input2.cpp"));
+                    srcmlArchive2.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                    srcmlArchive2.AddUnit(srcmlUnit);
+                    srcmlArchive2.ArchivePack();
 
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
-                    IntPtr structPtr2 = srcmlarchive2.GetPtrToStruct();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
+                    IntPtr structPtr2 = srcmlArchive2.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -89,20 +89,20 @@ namespace ABB.SrcML.Test {
         public void TestCreateSrcMLArchiveFtM() {
             IntPtr s = new IntPtr(0);
             List<String> documents = new List<String>();
-            using (Archive srcmlarchive = new Archive(), srcmlarchive2 = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitFilename(Path.Combine(TestInputPath, "input.cpp"));
-                    srcmlunit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
+            using (Archive srcmlArchive = new Archive(), srcmlArchive2 = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitFilename(Path.Combine(TestInputPath, "input.cpp"));
+                    srcmlUnit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
 
-                    srcmlunit.SetUnitFilename(Path.Combine(TestInputPath, "input2.cpp"));
-                    srcmlunit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                    srcmlarchive2.AddUnit(srcmlunit);
-                    srcmlarchive2.ArchivePack();
+                    srcmlUnit.SetUnitFilename(Path.Combine(TestInputPath, "input2.cpp"));
+                    srcmlUnit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                    srcmlArchive2.AddUnit(srcmlUnit);
+                    srcmlArchive2.ArchivePack();
 
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
-                    IntPtr structPtr2 = srcmlarchive2.GetPtrToStruct();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
+                    IntPtr structPtr2 = srcmlArchive2.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -151,32 +151,32 @@ namespace ABB.SrcML.Test {
         /// </summary>
         [Test]
         public void TestCreateSrcMLArchiveMtF() {
-            using (Archive srcmlarchive = new Archive()) {
-                List<String> BufferList = new List<String>();
-                List<String> FileList = new List<String>();
+            using (Archive srcmlArchive = new Archive()) {
+                List<String> bufferList = new List<String>();
+                List<String> fileList = new List<String>();
 
                 String str = "int main(){int c; c = 0; ++c;}";
                 String str2 = "int foo(){int c; c = 0; ++c;}";
 
-                FileList.Add("input.cpp");
-                FileList.Add("input2.cpp");
+                fileList.Add("input.cpp");
+                fileList.Add("input2.cpp");
 
-                BufferList.Add(str);
-                BufferList.Add(str2);
+                bufferList.Add(str);
+                bufferList.Add(str2);
 
-                var buffandfile = BufferList.Zip(FileList, (b, f) => new { buf = b, file = f });
+                var buffandfile = bufferList.Zip(fileList, (b, f) => new { buf = b, file = f });
                 foreach (var pair in buffandfile) {
-                    using (Unit srcmlunit = new Unit()) {
-                        srcmlunit.SetUnitBuffer(pair.buf);
-                        srcmlunit.SetUnitFilename(pair.file);
+                    using (Unit srcmlUnit = new Unit()) {
+                        srcmlUnit.SetUnitBuffer(pair.buf);
+                        srcmlUnit.SetUnitFilename(pair.file);
 
-                        srcmlarchive.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                        srcmlarchive.AddUnit(srcmlunit);
+                        srcmlArchive.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                        srcmlArchive.AddUnit(srcmlUnit);
                     }
                 }
-                srcmlarchive.ArchivePack();
+                srcmlArchive.ArchivePack();
 
-                IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+                IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                 List<IntPtr> structArrayPtr = new List<IntPtr>();
                 structArrayPtr.Add(structPtr);
@@ -210,30 +210,30 @@ namespace ABB.SrcML.Test {
         /// </summary>
         [Test]
         public void TestCreateSrcMLArchiveMtM() {
-            using (Archive srcmlarchive = new Archive()) {
-                List<String> BufferList = new List<String>();
-                List<String> FileList = new List<String>();
+            using (Archive srcmlArchive = new Archive()) {
+                List<String> bufferList = new List<String>();
+                List<String> fileList = new List<String>();
                 String str = "int main(){int c; c = 0; ++c;}";
                 String str2 = "int foo(){int c; c = 0; ++c;}";
-                BufferList.Add(str);
-                BufferList.Add(str2);
+                bufferList.Add(str);
+                bufferList.Add(str2);
 
-                FileList.Add("input.cpp");
-                FileList.Add("input2.cpp");
+                fileList.Add("input.cpp");
+                fileList.Add("input2.cpp");
 
-                var buffandfile = BufferList.Zip(FileList, (b, f) => new { buf = b, file = f });
+                var buffandfile = bufferList.Zip(fileList, (b, f) => new { buf = b, file = f });
                 foreach (var pair in buffandfile) {
-                    using (Unit srcmlunit = new Unit()) {
-                        srcmlunit.SetUnitBuffer(pair.buf);
-                        srcmlunit.SetUnitFilename(pair.file);
+                    using (Unit srcmlUnit = new Unit()) {
+                        srcmlUnit.SetUnitBuffer(pair.buf);
+                        srcmlUnit.SetUnitFilename(pair.file);
 
-                        srcmlunit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                        srcmlarchive.AddUnit(srcmlunit);
+                        srcmlUnit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                        srcmlArchive.AddUnit(srcmlUnit);
                     }
                 }
 
-                srcmlarchive.ArchivePack();
-                IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+                srcmlArchive.ArchivePack();
+                IntPtr structPtr = srcmlArchive.GetPtrToStruct();
                 List<IntPtr> structArrayPtr = new List<IntPtr>();
                 structArrayPtr.Add(structPtr);
                 IntPtr s = new IntPtr(0);
@@ -299,21 +299,21 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestGenerateSrcMLFromStrings() {
-            List<String> BufferList = new List<String>();
-            List<String> FileList = new List<String>();
+            List<String> bufferList = new List<String>();
+            List<String> fileList = new List<String>();
 
             String str = "int main(){int c; c = 0; ++c;}";
             String str2 = "int foo(){int c; c = 0; ++c;}";
 
-            FileList.Add("input.cpp");
-            FileList.Add("input2.cpp");
-            BufferList.Add(str);
-            BufferList.Add(str2);
+            fileList.Add("input.cpp");
+            fileList.Add("input2.cpp");
+            bufferList.Add(str);
+            bufferList.Add(str2);
 
             LibSrcMLRunner run = new LibSrcMLRunner();
 
             try {
-                List<string> b = run.GenerateSrcMLFromStrings(BufferList, FileList, Language.CPlusPlus, new Collection<UInt32>() { LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_MODIFIER }, false).ToList<string>();
+                List<string> b = run.GenerateSrcMLFromStrings(bufferList, fileList, Language.CPlusPlus, new Collection<UInt32>() { LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_MODIFIER }, false).ToList<string>();
                 Assert.True(Convert.ToBoolean(b.Count));
                 XDocument doc = XDocument.Parse(b.ElementAt(0));
                 var units = from unit in doc.Descendants(XName.Get("unit", "http://www.srcML.org/srcML/src"))
@@ -393,13 +393,13 @@ namespace ABB.SrcML.Test {
         #region WrapperTests
         [Test]
         public void TestArchiveSetSrcEncoding() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetArchiveSrcEncoding("ISO-8859-1");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetArchiveSrcEncoding("ISO-8859-1");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
 
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -409,12 +409,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveXmlEncoding() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetArchiveXmlEncoding("ISO-8859-1");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetArchiveXmlEncoding("ISO-8859-1");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -425,12 +425,12 @@ namespace ABB.SrcML.Test {
 
         [Test]
         public void TestArchiveSetLanguage() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -440,12 +440,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveSetUrl() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetArchiveUrl("http://www.srcml.org/");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetArchiveUrl("http://www.srcml.org/");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -455,12 +455,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveSetVersion() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetArchiveSrcVersion("1.0");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetArchiveSrcVersion("1.0");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -470,12 +470,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveSetOptions() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetOptions(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetOptions(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -485,12 +485,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveEnableOption() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.EnableOption(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.EnableOption(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -500,13 +500,13 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveDisableOption() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetOptions(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
-                    srcmlarchive.DisableOption(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetOptions(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
+                    srcmlArchive.DisableOption(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_LITERAL);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -516,12 +516,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveSetTabstop() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetArchiveTabstop(2);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetArchiveTabstop(2);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -531,12 +531,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveRegisterFileExtension() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.RegisterFileExtension("h", LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.RegisterFileExtension("h", LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -546,12 +546,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveRegisterNamespace() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.RegisterNamespace("abb", "www.abb.com");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.RegisterNamespace("abb", "www.abb.com");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -561,12 +561,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveSetProcessingInstruction() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.SetProcessingInstruction("hpp", "data");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.SetProcessingInstruction("hpp", "data");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -576,12 +576,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestArchiveRegisterMacro() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlarchive.RegisterMacro("Token", "type");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlArchive.RegisterMacro("Token", "type");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -591,12 +591,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitSetFilename() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitFilename("Bleep.cpp");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitFilename("Bleep.cpp");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -606,12 +606,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitSetLanguage() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -621,12 +621,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitSetSrcEncoding() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitSrcEncoding("UTF-8");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitSrcEncoding("UTF-8");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -636,12 +636,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitSetUrl() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitUrl("www.abb.com");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitUrl("www.abb.com");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -651,12 +651,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitSetVersion() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitSrcVersion("1.0");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitSrcVersion("1.0");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -666,12 +666,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitSetTimestamp() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetUnitTimestamp("0800");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetUnitTimestamp("0800");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -681,12 +681,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitSetHash() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.SetHash("hash");
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.SetHash("hash");
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);
@@ -696,12 +696,12 @@ namespace ABB.SrcML.Test {
         }
         [Test]
         public void TestUnitUnparseSetEol() {
-            using (Archive srcmlarchive = new Archive()) {
-                using (Unit srcmlunit = new Unit()) {
-                    srcmlunit.UnparseSetEol(50);
-                    srcmlarchive.AddUnit(srcmlunit);
-                    srcmlarchive.ArchivePack();
-                    IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            using (Archive srcmlArchive = new Archive()) {
+                using (Unit srcmlUnit = new Unit()) {
+                    srcmlUnit.UnparseSetEol(50);
+                    srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.ArchivePack();
+                    IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
                     List<IntPtr> structArrayPtr = new List<IntPtr>();
                     structArrayPtr.Add(structPtr);

--- a/ABB.SrcML.Test/LibSrcMLRunnerTests.cs
+++ b/ABB.SrcML.Test/LibSrcMLRunnerTests.cs
@@ -30,11 +30,13 @@ namespace ABB.SrcML.Test {
                     srcmlUnit.SetUnitFilename(Path.Combine(TestInputPath, "input.cpp"));
                     srcmlArchive.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
                     srcmlArchive.AddUnit(srcmlUnit);
+                    srcmlArchive.SetOutputFile("output");
                     srcmlArchive.ArchivePack();
 
                     srcmlUnit.SetUnitFilename(Path.Combine(TestInputPath, "input2.cpp"));
                     srcmlArchive2.SetArchiveLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
                     srcmlArchive2.AddUnit(srcmlUnit);
+                    srcmlArchive2.SetOutputFile("output");
                     srcmlArchive2.ArchivePack();
 
                     IntPtr structPtr = srcmlArchive.GetPtrToStruct();
@@ -45,7 +47,7 @@ namespace ABB.SrcML.Test {
                     structArrayPtr.Add(structPtr2);
 
                     try {
-                        Assert.True(LibSrcMLRunner.SrcmlCreateArchiveFtF(structArrayPtr.ToArray(), structArrayPtr.Count(), "output") == 0);
+                        Assert.True(LibSrcMLRunner.SrcmlCreateArchiveFtF(structArrayPtr.ToArray(), structArrayPtr.Count()) == IntPtr.Zero);
                     }
                     catch (SrcMLException e) {
                         Console.WriteLine(e.Message);
@@ -174,6 +176,7 @@ namespace ABB.SrcML.Test {
                         srcmlArchive.AddUnit(srcmlUnit);
                     }
                 }
+                srcmlArchive.SetOutputFile("output");
                 srcmlArchive.ArchivePack();
 
                 IntPtr structPtr = srcmlArchive.GetPtrToStruct();
@@ -181,7 +184,7 @@ namespace ABB.SrcML.Test {
                 List<IntPtr> structArrayPtr = new List<IntPtr>();
                 structArrayPtr.Add(structPtr);
 
-                Assert.True(LibSrcMLRunner.SrcmlCreateArchiveMtF(structArrayPtr.ToArray(), structArrayPtr.Count(), "output") == 0);
+                Assert.True(LibSrcMLRunner.SrcmlCreateArchiveMtF(structArrayPtr.ToArray(), structArrayPtr.Count()) == IntPtr.Zero);
                 Assert.True(File.Exists("output0.cpp.xml"));
 
                 SrcMLFile srcFile = new SrcMLFile("output0.cpp.xml");

--- a/ABB.SrcML/LibSrcMLRunner.cs
+++ b/ABB.SrcML/LibSrcMLRunner.cs
@@ -52,11 +52,11 @@ namespace ABB.SrcML {
         /// Set an option to be used by the parser on the archive
         /// </summary>
         /// <param name="srcOption"></param>
-        public string OutputFile{
+        public string OutputFile {
             get { return Marshal.PtrToStringAnsi(archive.outputFile); }
             set { archive.outputFile = Marshal.StringToHGlobalAnsi(value); }
         }
-         
+
         #region ArchiveMutatorFunctions
         /// <summary>
         /// Set an option to be used by the parser on the archive
@@ -199,7 +199,7 @@ namespace ABB.SrcML {
         /// <summary>
         /// Add a unit to the archive
         /// </summary>
-        /// <param name="unit">a srcmlunit allocated via ABB.SrcML.Unit class</param>
+        /// <param name="unit">a srcmlUnit allocated via ABB.SrcML.Unit class</param>
         public void AddUnit(Unit unit) {
             ++unit.referencecount;
             units.Add(unit);
@@ -483,19 +483,19 @@ namespace ABB.SrcML {
         public void GenerateSrcMLFromFiles(ICollection<string> fileNames, string xmlFileName, Language language, ICollection<UInt32> namespaceArguments, IDictionary<string, Language> extensionMapping) {
             UInt32 arguments = GenerateArguments(namespaceArguments);
             try {
-                using (Archive srcmlarchive = new Archive()) {
+                using (Archive srcmlArchive = new Archive()) {
                     if (Convert.ToBoolean(extensionMapping.Count())) {
-                        srcmlarchive.RegisterFileExtension(extensionMapping.ElementAt(0).Key, extensionMapping.ElementAt(0).Value.ToString());
+                        srcmlArchive.RegisterFileExtension(extensionMapping.ElementAt(0).Key, extensionMapping.ElementAt(0).Value.ToString());
                     }
                     foreach (string file in fileNames) {
-                        using (Unit srcmlunit = new Unit()) {
-                            srcmlunit.SetUnitFilename(file);
-                            srcmlunit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
-                            srcmlarchive.AddUnit(srcmlunit);
+                        using (Unit srcmlUnit = new Unit()) {
+                            srcmlUnit.SetUnitFilename(file);
+                            srcmlUnit.SetUnitLanguage(LibSrcMLRunner.SrcMLLanguages.SRCML_LANGUAGE_CXX);
+                            srcmlArchive.AddUnit(srcmlUnit);
                         }
                     }
-                    srcmlarchive.SetOutputFile(xmlFileName);
-                    RunSrcML(srcmlarchive, LibSrcMLRunner.SrcmlCreateArchiveFtF);
+                    srcmlArchive.SetOutputFile(xmlFileName);
+                    RunSrcML(srcmlArchive, LibSrcMLRunner.SrcmlCreateArchiveFtF);
                 }
             }
             catch (Exception e) {
@@ -533,22 +533,22 @@ namespace ABB.SrcML {
         public ICollection<string> GenerateSrcMLFromStrings(ICollection<string> sources, ICollection<string> unitFilename, Language language, ICollection<UInt32> namespaceArguments, bool omitXmlDeclaration) {
             Contract.Requires(sources.Count == unitFilename.Count);
             try {
-                using (Archive srcmlarchive = new Archive()) {
-                    srcmlarchive.SetArchiveLanguage(LanguageEnumDictionary[language]);
-                    srcmlarchive.EnableOption(GenerateArguments(namespaceArguments));
+                using (Archive srcmlArchive = new Archive()) {
+                    srcmlArchive.SetArchiveLanguage(LanguageEnumDictionary[language]);
+                    srcmlArchive.EnableOption(GenerateArguments(namespaceArguments));
                     var sourceandfile = sources.Zip(unitFilename, (src, fle) => new { source = src, file = fle });
-                    foreach(var pair in sourceandfile){
-                        using (Unit srcmlunit = new Unit()) {
+                    foreach (var pair in sourceandfile) {
+                        using (Unit srcmlUnit = new Unit()) {
                             if (omitXmlDeclaration) {
-                                srcmlarchive.DisableOption(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_XML_DECL);
+                                srcmlArchive.DisableOption(LibSrcMLRunner.SrcMLOptions.SRCML_OPTION_XML_DECL);
                             }
-                            srcmlunit.SetUnitBuffer(pair.source);
-                            srcmlunit.SetUnitFilename(pair.file);
-                            srcmlunit.SetUnitLanguage(LanguageEnumDictionary[language]);
-                            srcmlarchive.AddUnit(srcmlunit);
+                            srcmlUnit.SetUnitBuffer(pair.source);
+                            srcmlUnit.SetUnitFilename(pair.file);
+                            srcmlUnit.SetUnitLanguage(LanguageEnumDictionary[language]);
+                            srcmlArchive.AddUnit(srcmlUnit);
                         }
                     }
-                    return RunSrcML(srcmlarchive, LibSrcMLRunner.SrcmlCreateArchiveMtM);
+                    return RunSrcML(srcmlArchive, LibSrcMLRunner.SrcmlCreateArchiveMtM);
                 }
             }
             catch (Exception e) {
@@ -556,10 +556,10 @@ namespace ABB.SrcML {
             }
         }
 
-        private List<string> RunSrcML(Archive srcmlarchive, Func<IntPtr[], int, IntPtr> func){
-            srcmlarchive.ArchivePack();
+        private List<string> RunSrcML(Archive srcmlArchive, Func<IntPtr[], int, IntPtr> func) {
+            srcmlArchive.ArchivePack();
 
-            IntPtr structPtr = srcmlarchive.GetPtrToStruct();
+            IntPtr structPtr = srcmlArchive.GetPtrToStruct();
 
             List<IntPtr> structArrayPtr = new List<IntPtr>();
             structArrayPtr.Add(structPtr);
@@ -567,13 +567,13 @@ namespace ABB.SrcML {
             IntPtr s = func(structArrayPtr.ToArray(), structArrayPtr.Count());
 
             if (s == IntPtr.Zero) {
-                return new List<string>(){srcmlarchive.OutputFile};
+                return new List<string>() { srcmlArchive.OutputFile };
             }
 
             IntPtr docptr = Marshal.ReadIntPtr(s);
             string docstr = Marshal.PtrToStringAnsi(docptr);
 
-            return new List<string>(){docstr};
+            return new List<string>() { docstr };
         }
 
         /// <summary>

--- a/LibSrcMLWrapper/LibSrcMLWrapper.cpp
+++ b/LibSrcMLWrapper/LibSrcMLWrapper.cpp
@@ -5,13 +5,13 @@ using namespace System;
 using namespace System::Runtime::InteropServices;
 
 extern"C"{
-    /*
+    
     void SetArchiveData(srcml_archive* archive, LibSrcMLWrapper::SourceData* sd){
-        if (sd->src_encoding){
-            srcml_archive_set_src_encoding(archive, sd->src_encoding);
+        if (sd->srcEncoding){
+            srcml_archive_set_src_encoding(archive, sd->srcEncoding);
         }
-        if (sd->encoding){
-            srcml_archive_set_xml_encoding(archive, sd->encoding);
+        if (sd->xmlEncoding){
+            srcml_archive_set_xml_encoding(archive, sd->xmlEncoding);
         }
         if (sd->language){
             srcml_archive_set_language(archive, sd->language);
@@ -46,34 +46,31 @@ extern"C"{
         if (sd->tokenandtype){
             srcml_archive_register_macro(archive, sd->tokenandtype[0], sd->tokenandtype[1]);
         }
-        if (sd->eol){
-            srcml_unparse_set_eol(sd->eol);
+    }
+    
+    void SetUnitData(srcml_unit* unit, LibSrcMLWrapper::UnitData* clientUnit){
+        if (clientUnit->language){
+            srcml_unit_set_language(unit, clientUnit->language);
         }
-    }*/
-    /*
-    void SetUnitData(srcml_unit* unit, LibSrcMLWrapper::SourceData* sd){
-        if (sd->language){
-            srcml_unit_set_language(unit, sd->language);
+        if (clientUnit->encoding){
+            srcml_unit_set_src_encoding(unit, clientUnit->encoding);
         }
-        if (sd->src_encoding){
-            srcml_unit_set_src_encoding(unit, sd->src_encoding);
+        if (clientUnit->url){
+            srcml_unit_set_url(unit, clientUnit->url);
         }
-        if (sd->url){
-            srcml_unit_set_url(unit, sd->url);
+        if (clientUnit->version){
+            srcml_unit_set_version(unit, clientUnit->version);
         }
-        if (sd->version){
-            srcml_unit_set_version(unit, sd->version);
+        if (clientUnit->timestamp){
+            srcml_unit_set_timestamp(unit, clientUnit->timestamp);
         }
-        if (sd->timestamp){
-            srcml_unit_set_timestamp(unit, sd->timestamp);
+        if (clientUnit->hash){
+            srcml_unit_set_hash(unit, clientUnit->hash);
         }
-        if (sd->hash){
-            srcml_unit_set_hash(unit, sd->hash);
+        if (clientUnit->eol){
+            srcml_unit_unparse_set_eol(unit, clientUnit->eol);
         }
-        if (sd->eol){
-            srcml_unit_unparse_set_eol(unit, sd->eol);
-        }
-    }*/
+    }
     /// <summary>
     /// This creates an archive from a list of files and saves to a file
     /// </summary>
@@ -87,7 +84,7 @@ extern"C"{
         for (int i = 0; i < argc; ++i){
             /*create a new srcml archive structure */
             archive = srcml_archive_create();
-           // SetArchiveData(archive, sd[i]);
+           SetArchiveData(archive, sd[i]);
 
             std::string filename(outputFile);
             filename += std::to_string(i) + ".cpp.xml";
@@ -101,10 +98,9 @@ extern"C"{
                 unit = srcml_unit_create(archive);
 
                 /*Set all srcML options provided through sd*/
-                //SetUnitData(unit, sd[i]);
+                SetUnitData(unit, &sd[i]->units[k]);
 
                 /*Set filename for unit*/
-                Console::WriteLine(String::Format("could not parse file {0}. SrcML returned with status {1}", gcnew String(sd[i]->units[k].filename), srcmlreturncode));
                 srcml_unit_set_filename(unit, sd[i]->units[k].filename);
 
                 /*Translate to srcml and append to the archive */
@@ -142,7 +138,7 @@ extern"C"{
         for (int i = 0; i < argc; ++i){
             /* create a new srcml archive structure */
             archive = srcml_archive_create();
-            //SetArchiveData(archive, sd[i]);
+            SetArchiveData(archive, sd[i]);
 
             /* open a srcML archive for output */
             std::string filename(outputFile);
@@ -158,7 +154,7 @@ extern"C"{
                 unit = srcml_unit_create(archive);
 
                 /*Set all srcML options provided through sd*/
-                //SetUnitData(unit, sd[i]);
+                SetUnitData(unit, &sd[i]->units[k]);
 
                 /*Set filename for unit*/
                 srcml_unit_set_filename(unit, sd[i]->units[k].filename);
@@ -199,7 +195,7 @@ extern"C"{
             /* create a new srcml archive structure */
             struct srcml_archive* archive;
             archive = srcml_archive_create();
-            //SetArchiveData(archive, sd[i]);
+            SetArchiveData(archive, sd[i]);
 
             /* open a srcML archive for output */
             srcml_archive_write_open_memory(archive, &pp[i], &size);
@@ -208,7 +204,7 @@ extern"C"{
                 unit = srcml_unit_create(archive);
 
                 /*Set all srcML options provided through sd*/
-                //SetUnitData(unit, sd[i]);
+                SetUnitData(unit, &sd[i]->units[k]);
 
                 /*Set filename for unit*/
                 srcml_unit_set_filename(unit, sd[i]->units[k].filename);
@@ -263,7 +259,7 @@ extern"C"{
             struct srcml_archive* archive;
             /* create a new srcml archive structure */
             archive = srcml_archive_create();
-            //SetArchiveData(archive, sd[i]);
+            SetArchiveData(archive, sd[i]);
             /* open a srcML archive for output */
             srcml_archive_write_open_memory(archive, &pp[i], &size);
             for (int k = 0; k < sd[i]->unitCount; ++k){
@@ -271,7 +267,7 @@ extern"C"{
                 unit = srcml_unit_create(archive);
 
                 /*Set all srcML options provided through sd*/
-                //SetUnitData(unit, sd[i]);
+                SetUnitData(unit, &sd[i]->units[k]);
 
                 /*Set filename for unit*/
                 srcml_unit_set_filename(unit, sd[i]->units[k].filename);

--- a/LibSrcMLWrapper/LibSrcMLWrapper.cpp
+++ b/LibSrcMLWrapper/LibSrcMLWrapper.cpp
@@ -77,7 +77,7 @@ extern"C"{
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
     ///<param name="outputFile">File to output to</param>
-    __declspec(dllexport) int SrcmlCreateArchiveFtF(LibSrcMLWrapper::SourceData** sd, int argc, const char* outputFile) {
+    __declspec(dllexport) int SrcmlCreateArchiveFtF(LibSrcMLWrapper::SourceData** sd, int argc) {
         struct srcml_archive* archive;
         struct srcml_unit* unit;
         int srcmlreturncode = -1;
@@ -86,7 +86,7 @@ extern"C"{
             archive = srcml_archive_create();
            SetArchiveData(archive, sd[i]);
 
-            std::string filename(outputFile);
+            std::string filename(sd[i]->outputFile);
             filename += std::to_string(i) + ".cpp.xml";
 
             /*open a srcML archive for output */
@@ -131,7 +131,7 @@ extern"C"{
     ///<param name="argv">List of files to be read</param>
     ///<param name="argc">Number of arguments in argv</param>
     ///<param name="outputFile">File to output to</param>
-    __declspec(dllexport) int SrcmlCreateArchiveMtF(LibSrcMLWrapper::SourceData** sd, int argc, const char* outputFile) {
+    __declspec(dllexport) int SrcmlCreateArchiveMtF(LibSrcMLWrapper::SourceData** sd, int argc) {
         struct srcml_archive* archive;
         struct srcml_unit* unit;
         int srcmlreturncode = -1;
@@ -141,7 +141,7 @@ extern"C"{
             SetArchiveData(archive, sd[i]);
 
             /* open a srcML archive for output */
-            std::string filename(outputFile);
+            std::string filename(sd[i]->outputFile);
             filename += std::to_string(i) + ".cpp.xml";
 
             /*open a srcML archive for output */

--- a/LibSrcMLWrapper/LibSrcMLWrapper.h
+++ b/LibSrcMLWrapper/LibSrcMLWrapper.h
@@ -35,6 +35,7 @@ namespace LibSrcMLWrapper {
         char* version;
         char* srcEncoding;
         char* xmlEncoding;
+        char* outputFile;
         UnitData* units;
     };
     /// <summary>

--- a/LibSrcMLWrapper/LibSrcMLWrapper.h
+++ b/LibSrcMLWrapper/LibSrcMLWrapper.h
@@ -7,19 +7,21 @@ using namespace System::Runtime::InteropServices;
 #include <fstream>
 #include <iostream>
 namespace LibSrcMLWrapper {
-    public struct SourceData {
+    public struct UnitData{
         char* encoding;
-        char* src_encoding;
         char* revision;
         char* language;
-        char** filename;
+        char* filename;
         char* url;
         char* version;
         char* timestamp;
         char* hash;
-        char** buffer;
-        int buffercount;
-        int* buffersize;
+        int eol;
+        char* buffer;
+        int bufferSize;
+    };
+    public struct SourceData {
+        int unitCount;
         int tabstop;
         unsigned long optionSet;
         unsigned long optionEnable;
@@ -28,7 +30,12 @@ namespace LibSrcMLWrapper {
         char** prefixandnamespace;
         char** targetanddata;
         char** tokenandtype;
-        int eol;
+        char* url;
+        char* language;
+        char* version;
+        char* srcEncoding;
+        char* xmlEncoding;
+        UnitData* units;
     };
     /// <summary>
     /// Utility function that trims from the right of a string. For now it's just solving a weird issue with srcML

--- a/LibSrcMLWrapper/WrapperTestInterface.h
+++ b/LibSrcMLWrapper/WrapperTestInterface.h
@@ -1,11 +1,11 @@
 #include "stdafx.h"
 using System::String;
 extern"C"{
-    __declspec(dllexport) inline bool TestArchiveSetXmlEncoding(LibSrcMLWrapper::SourceData** sd){
+    __declspec(dllexport) inline bool TestArchiveSetSrcEncoding(LibSrcMLWrapper::SourceData** sd){
         struct srcml_archive* archive;
         archive = srcml_archive_create();
-        srcml_archive_set_xml_encoding(archive, sd[0]->encoding);
-        if (srcml_archive_get_xml_encoding(archive)){
+        srcml_archive_set_src_encoding(archive, sd[0]->srcEncoding);
+        if (srcml_archive_get_src_encoding(archive)){
             srcml_archive_close(archive);
             srcml_archive_free(archive);
             return true;
@@ -16,11 +16,13 @@ extern"C"{
             return false;
         }
     }
-    __declspec(dllexport) inline bool TestArchiveSetSrcEncoding(LibSrcMLWrapper::SourceData** sd){
+
+
+    __declspec(dllexport) inline bool TestArchiveSetXmlEncoding(LibSrcMLWrapper::SourceData** sd){
         struct srcml_archive* archive;
         archive = srcml_archive_create();
-        srcml_archive_set_src_encoding(archive, sd[0]->src_encoding);
-        if (srcml_archive_get_src_encoding(archive)){
+        srcml_archive_set_xml_encoding(archive, sd[0]->xmlEncoding);
+        if (srcml_archive_get_xml_encoding(archive)){
             srcml_archive_close(archive);
             srcml_archive_free(archive);
             return true;
@@ -209,9 +211,9 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        srcml_unit_set_filename(unit, sd[0]->filename[0]);
+        srcml_unit_set_filename(unit, sd[0]->units[0].filename);
         const char* ufname = srcml_unit_get_filename(unit);
-        if (std::strcmp(sd[0]->filename[0], ufname) == 0){
+        if (std::strcmp(sd[0]->units[0].filename, ufname) == 0){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
             srcml_archive_free(archive);
@@ -229,9 +231,9 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        srcml_unit_set_language(unit, sd[0]->language);
+        srcml_unit_set_language(unit, sd[0]->units[0].language);
         const char* lang = srcml_unit_get_language(unit);
-        if (std::strcmp(sd[0]->language, lang) == 0){
+        if (std::strcmp(sd[0]->units[0].language, lang) == 0){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
             srcml_archive_free(archive);
@@ -249,7 +251,7 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        srcml_unit_set_src_encoding(unit, sd[0]->src_encoding);
+        srcml_unit_set_src_encoding(unit, sd[0]->units[0].encoding);
         if (std::strcmp(srcml_unit_get_src_encoding(unit), "UTF-8") == 0){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
@@ -268,7 +270,7 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        srcml_unit_set_url(unit, sd[0]->url);
+        srcml_unit_set_url(unit, sd[0]->units[0].url);
         if (std::strcmp(srcml_unit_get_url(unit), "www.abb.com") == 0){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
@@ -287,7 +289,7 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        srcml_unit_set_version(unit, sd[0]->version);
+        srcml_unit_set_version(unit, sd[0]->units[0].version);
         if (std::strcmp(srcml_unit_get_version(unit), "1.0") == 0){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
@@ -306,7 +308,7 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        srcml_unit_set_timestamp(unit, sd[0]->timestamp);
+        srcml_unit_set_timestamp(unit, sd[0]->units[0].timestamp);
         if (std::strcmp(srcml_unit_get_timestamp(unit), "0800") == 0){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
@@ -325,7 +327,7 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        srcml_unit_set_hash(unit, sd[0]->hash);
+        srcml_unit_set_hash(unit, sd[0]->units[0].hash);
         if (std::strcmp(srcml_unit_get_hash(unit), "hash") == 0){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
@@ -344,7 +346,7 @@ extern"C"{
         archive = srcml_archive_create();
         struct srcml_unit *unit;
         unit = srcml_unit_create(archive);
-        if (srcml_unit_unparse_set_eol(unit, sd[0]->eol)){
+        if (srcml_unit_unparse_set_eol(unit, sd[0]->units[0].eol)){
             srcml_unit_free(unit);
             srcml_archive_close(archive);
             srcml_archive_free(archive);

--- a/LibSrcMLWrapper/WrapperTestInterface.h
+++ b/LibSrcMLWrapper/WrapperTestInterface.h
@@ -113,7 +113,7 @@ extern"C"{
     __declspec(dllexport) inline bool TestArchiveDisableOption(LibSrcMLWrapper::SourceData** sd){
         struct srcml_archive* archive;
         archive = srcml_archive_create();
-        srcml_archive_enable_option(archive, SRCML_OPTION_LITERAL);
+        srcml_archive_enable_option(archive, sd[0]->optionSet);
         unsigned long opts = srcml_archive_get_options(archive);
         srcml_archive_disable_option(archive, sd[0]->optionDisable);
         if (srcml_archive_get_options(archive) != opts){


### PR DESCRIPTION
Data structure I was using before was clumsy and just not great to work with so I made a large number of changes.

-Archive and Unit are now split into their own classes
-LibSrcmlRunner is now ONLY for managing functions that generate srcML in various ways
-Memory management is much cleaner
-All tests and srcml generation functions have been fixed to work with new DS
-This addresses issues #61 and #63 
Future changes planned:
-The use of archive's archivepack() function is a little awkward, I think. I'll be looking at ways to remove the need for it to be called explicitly by anyone who writes future srcml generation functions. Most likely it'll end up in a function automatically called before shipping off to C++ for processing.
-Will be looking at good ways to avoid writing a ton of generation functions and, instead, make something more generic